### PR TITLE
#144 Correct an issue where a violation report could not be added to the CSP

### DIFF
--- a/src/Stott.Security.Optimizely.Test/Features/Permissions/Repository/CspPermissionRepositoryTestCases.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Permissions/Repository/CspPermissionRepositoryTestCases.cs
@@ -2,6 +2,8 @@
 
 using NUnit.Framework;
 
+using Stott.Security.Optimizely.Common;
+
 namespace Stott.Security.Optimizely.Test.Features.Permissions.Repository
 {
     public static class CspPermissionRepositoryTestCases
@@ -12,6 +14,21 @@ namespace Stott.Security.Optimizely.Test.Features.Permissions.Repository
             {
                 yield return new TestCaseData((List<string>)null);
                 yield return new TestCaseData(new List<string>(0));
+            }
+        }
+
+        public static IEnumerable<TestCaseData> AppendHandlesSimilarDirectivesTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(CspConstants.Directives.ScriptSourceElement, CspConstants.Directives.ScriptSource, $"{CspConstants.Directives.ScriptSourceElement},{CspConstants.Directives.ScriptSource}");
+                yield return new TestCaseData(CspConstants.Directives.ScriptSource, CspConstants.Directives.ScriptSourceElement, $"{CspConstants.Directives.ScriptSource},{CspConstants.Directives.ScriptSourceElement}");
+                yield return new TestCaseData(CspConstants.Directives.ScriptSourceElement, CspConstants.Directives.ScriptSourceElement, CspConstants.Directives.ScriptSourceElement);
+                yield return new TestCaseData(CspConstants.Directives.ScriptSource, CspConstants.Directives.ScriptSource, CspConstants.Directives.ScriptSource);
+                yield return new TestCaseData(CspConstants.Directives.StyleSourceElement, CspConstants.Directives.StyleSource, $"{CspConstants.Directives.StyleSourceElement},{CspConstants.Directives.StyleSource}");
+                yield return new TestCaseData(CspConstants.Directives.StyleSource, CspConstants.Directives.StyleSourceElement, $"{CspConstants.Directives.StyleSource},{CspConstants.Directives.StyleSourceElement}");
+                yield return new TestCaseData(CspConstants.Directives.StyleSourceElement, CspConstants.Directives.StyleSourceElement, CspConstants.Directives.StyleSourceElement);
+                yield return new TestCaseData(CspConstants.Directives.StyleSource, CspConstants.Directives.StyleSource, CspConstants.Directives.StyleSource);
             }
         }
     }

--- a/src/Stott.Security.Optimizely/Features/Permissions/Repository/CspPermissionRepository.cs
+++ b/src/Stott.Security.Optimizely/Features/Permissions/Repository/CspPermissionRepository.cs
@@ -100,7 +100,7 @@ internal sealed class CspPermissionRepository : ICspPermissionRepository
                 ModifiedBy = modifiedBy
             });
         }
-        else if (!matchingSource.Directives.Contains(directive))
+        else if (!HasDirective(matchingSource.Directives, directive))
         {
             matchingSource.Directives = $"{matchingSource.Directives},{directive}";
             matchingSource.Modified = DateTime.UtcNow;
@@ -136,5 +136,15 @@ internal sealed class CspPermissionRepository : ICspPermissionRepository
         recordToSave.ModifiedBy = modifiedBy;
 
         await _cspDataContext.SaveChangesAsync();
+    }
+
+    private static bool HasDirective(string? currentDirectives, string? directive)
+    {
+        if (string.IsNullOrWhiteSpace(currentDirectives)) return false;
+
+        if (string.IsNullOrWhiteSpace(directive)) return true;
+
+        return currentDirectives.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                                .Contains(directive);
     }
 }


### PR DESCRIPTION
Correct an issue where a violation report could not be added to the CSP because the violated directive less specific than one already assigned.

Closes #144