### PR TITLE
Update CORS handling to be compatible with code based policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,12 @@ services.AddCors(x =>
 });
 ```
 
-On a Controller Action that then uses the `[EnableCors("TEST-POLICY")]`, then the policy as defined in code will be used.  In all other cases the CORS policy defined by this module will be used instead.
+On a Controller Action that then uses the `[EnableCors("TEST-POLICY")]`, if the policy has been defined in code, then it will be used.  In all other cases the CORS policy defined by this module will be used instead.  The priority of which policy is used is in the following order:
+
+- If the provided policy name is null or empty or whitespace, then the module policy will be used.
+- If the provided policy name matches the module policy name, then the module policy will be used.
+- If a code based policy is found that matches the provided policy name, then the code based policy will be used.
+- If a code based policy cannot be found that It the requested policy name, then the module policy will be used.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ This module hooks into the Optimizely PublishingContent events as exposed by `IC
 
 ## Cross-Origin Resource Sharing
 
-Support for managing the CORS headers has been introduced within version 2.0.0.0 and is currently in BETA.
+Support for managing the CORS headers has been introduced within version 2.0.0.0.
 
 ### Configuration
 
@@ -290,9 +290,27 @@ services.AddCors();
 builder.UseCors(...);
 ```
 
-In beta, the standard configuration will set up a CORS Policy of `Stott:SecurityOptimizely:CORS` which is defined as a static variable as `CspConstants.CorsPolicy` that will be used for the entire website.  Microsoft's default implementation of `ICorsPolicyProvider` is replaced with a custom implementation within this package called `CustomCorsPolicyProvider` that will always load the policy as defined in the administration interface.
+The standard configuration will set up a CORS Policy of `Stott:SecurityOptimizely:CORS` which is defined as a static variable as `CspConstants.CorsPolicy` that will be used for the entire website.  Microsoft's default implementation of `ICorsPolicyProvider` is replaced with a custom implementation within this package called `CustomCorsPolicyProvider` that will always load the policy as defined in the administration interface.
 
-Intent exists to update this Custom CORS Policy Provider so that it will load the policy defined within the interface based on specified policy of `Stott:SecurityOptimizely:CORS` and to allow additional hard coded policies to be provided for use within CORS controller attributes.
+### Support For Additional CORS Policies
+
+*Introduced in 2.2.0*
+
+If you want to make an exception to the CORS Policy of `Stott:SecurityOptimizely:CORS` for a specific route.  Then you can define an additional hard coded CORS Policy using the `services.AddCors(...)` method as follows:
+
+```C#
+services.AddCors(x =>
+{
+    x.AddPolicy("TEST-POLICY", x =>
+    {
+        x.AllowAnyMethod();
+        x.AllowAnyOrigin();
+        x.AllowAnyHeader();
+    });
+});
+```
+
+On a Controller Action that then uses the `[EnableCors("TEST-POLICY")]`, then the policy as defined in code will be used.  In all other cases the CORS policy defined by this module will be used instead.
 
 ## FAQ
 

--- a/Sample/OptimizelyTwelveTest/Features/API/TestApiController.cs
+++ b/Sample/OptimizelyTwelveTest/Features/API/TestApiController.cs
@@ -1,0 +1,20 @@
+namespace OptimizelyTwelveTest.Features.API;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+[EnableCors("TEST-POLICY")]
+public sealed class TestApiController : Controller
+{
+    [HttpGet]
+    [Route("/api/test/list")]
+    public IActionResult List([FromQuery]string nameToReturn)
+    {
+        var list = new List<string> { "Foo", "Bar", nameToReturn };
+
+        return Json(list.Where(x => !string.IsNullOrWhiteSpace(x)));
+    }
+}

--- a/Sample/OptimizelyTwelveTest/Startup.cs
+++ b/Sample/OptimizelyTwelveTest/Startup.cs
@@ -5,6 +5,7 @@
     using EPiServer.Web.Routing;
 
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Cors.Infrastructure;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -76,6 +77,16 @@
             services.ConfigureApplicationCookie(options =>
             {
                 options.LoginPath = "/util/Login";
+            });
+
+            services.AddCors(x =>
+            {
+                x.AddPolicy("TEST-POLICY", x =>
+                {
+                    x.AllowAnyMethod();
+                    x.AllowAnyOrigin();
+                    x.AllowAnyHeader();
+                });
             });
         }
 

--- a/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTestCases.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTestCases.cs
@@ -1,0 +1,21 @@
+﻿namespace Stott.Security.Optimizely.Test.Features.Cors.Provider;
+
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Stott.Security.Optimizely.Common;
+
+public static class CustomCorsPolicyProviderTestCases
+{
+    public static IEnumerable<TestCaseData> GetNullOrDefaultPolicyNameTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(null);
+            yield return new TestCaseData("");
+            yield return new TestCaseData(" ");
+            yield return new TestCaseData(CspConstants.CorsPolicy);
+        }
+    }
+}

--- a/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTests.cs
@@ -1,0 +1,92 @@
+﻿namespace Stott.Security.Optimizely.Test.Features.Cors.Provider;
+
+using System;
+using System.Threading.Tasks;
+
+using JetBrains.Annotations;
+
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Stott.Security.Optimizely.Features.Caching;
+using Stott.Security.Optimizely.Features.Cors;
+using Stott.Security.Optimizely.Features.Cors.Provider;
+using Stott.Security.Optimizely.Features.Cors.Service;
+
+[TestFixture]
+public sealed class CustomCorsPolicyProviderTests
+{
+    private Mock<ICacheWrapper> _mockCache;
+
+    private Mock<ICorsSettingsService> _mockService;
+
+    private Mock<IOptions<CorsOptions>> _mockOptions;
+
+    private Mock<HttpContext> _mockHttpContext;
+
+    private CustomCorsPolicyProvider _provider;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockCache = new Mock<ICacheWrapper>();
+
+        _mockService = new Mock<ICorsSettingsService>();
+        _mockService.Setup(x => x.GetAsync()).ReturnsAsync(new CorsConfiguration());
+
+        _mockHttpContext = new Mock<HttpContext>();
+
+        var corsOptions = new CorsOptions();
+        corsOptions.AddPolicy("Test-Policy", x =>
+        {
+            x.AllowAnyHeader();
+            x.AllowAnyMethod();
+            x.AllowAnyOrigin();
+        });
+
+        _mockOptions = new Mock<IOptions<CorsOptions>>();
+        _mockOptions.Setup(x => x.Value).Returns(corsOptions);
+
+        _provider = new CustomCorsPolicyProvider(_mockCache.Object, _mockService.Object, _mockOptions.Object);
+    }
+
+    [Test]
+    public async Task GivenTheProvidedPolicyNameMatchesAConfigurationInCode_ThenPolicyWillNotBeLoadedFromCacheOrDatabase()
+    {
+        // Act
+        _ = await _provider.GetPolicyAsync(_mockHttpContext.Object, "Test-Policy");
+
+        // Assert
+        _mockCache.Verify(x => x.Get<CorsPolicy>(It.IsAny<string>()), Times.Never());
+        _mockService.Verify(x => x.GetAsync(), Times.Never());
+    }
+
+    [Test]
+    public async Task GivenTheProvidedPolicyNameDoesNotMatchAConfigurationInCode_ThenPolicyWillBeLoadedFromCacheOrDatabase()
+    {
+        // Act
+        _ = await _provider.GetPolicyAsync(_mockHttpContext.Object, Guid.NewGuid().ToString());
+
+        // Assert
+        _mockCache.Verify(x => x.Get<CorsPolicy>(It.IsAny<string>()), Times.Once());
+        _mockService.Verify(x => x.GetAsync(), Times.Once());
+    }
+
+    [Test]
+    [TestCaseSource(typeof(CustomCorsPolicyProviderTestCases), nameof(CustomCorsPolicyProviderTestCases.GetNullOrDefaultPolicyNameTestCases))]
+    public async Task GivenTheProvidedPolicyNameIsEmptyOrMatchesTheModuleDefault_ThenPolicyWillBeLoadedFromCacheOrDatabase(
+        [CanBeNull]string policyName)
+    {
+        // Act
+        _ = await _provider.GetPolicyAsync(_mockHttpContext.Object, policyName);
+
+        // Assert
+        _mockCache.Verify(x => x.Get<CorsPolicy>(It.IsAny<string>()), Times.Once());
+        _mockService.Verify(x => x.GetAsync(), Times.Once());
+    }
+}


### PR DESCRIPTION
This updates the CORS Policy Provider to use a CORS Policy defined in code.  

- If the provided policy name is null or empty or whitespace, then the module policy will be used.
- If the provided policy name matches the module policy name, then the module policy will be used.
- If a code based policy is found that matches the provided policy name, then the code based policy will be used.
- If a code based policy cannot be found that It the requested policy name, then the module policy will be used.