### PR TITLE
Reduce the number of times the DB Context is instantiated on normal requests and reduce the number of DB calls.

### DIFF
--- a/Sample/OptimizelyTwelveTest/Startup.cs
+++ b/Sample/OptimizelyTwelveTest/Startup.cs
@@ -6,6 +6,7 @@ using EPiServer.Web.Routing;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
@@ -115,7 +116,7 @@ public class Startup
                 }
                 else
                 {
-                    context.Response.Headers.Add(HeaderNames.CacheControl, "no-cache, max-age=0");
+                    context.Response.Headers.Append(HeaderNames.CacheControl, "no-cache, max-age=0");
                 }
             }
 

--- a/src/Stott.Security.Optimizely.Test/Features/AllowList/WhitelistServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/AllowList/WhitelistServiceTests.cs
@@ -15,13 +15,13 @@ using Stott.Security.Optimizely.Entities;
 using Stott.Security.Optimizely.Features.AllowList;
 using Stott.Security.Optimizely.Features.Caching;
 using Stott.Security.Optimizely.Features.Permissions.Service;
-using Stott.Security.Optimizely.Features.Settings.Repository;
+using Stott.Security.Optimizely.Features.Settings.Service;
 using Stott.Security.Optimizely.Test.TestCases;
 
 [TestFixture]
 public class AllowListServiceTests
 {
-    private Mock<ICspSettingsRepository> _mockSettingsRepository;
+    private Mock<ICspSettingsService> _mockSettingsService;
 
     private Mock<IAllowListRepository> _mockRepository;
 
@@ -36,14 +36,14 @@ public class AllowListServiceTests
     [SetUp]
     public void SetUp()
     {
-        _mockSettingsRepository = new Mock<ICspSettingsRepository>();
+        _mockSettingsService = new Mock<ICspSettingsService>();
         _mockRepository = new Mock<IAllowListRepository>();
         _mockCspPermissionService = new Mock<ICspPermissionService>();
         _mockLogger = new Mock<ILogger<IAllowListService>>();
         _mockCacheWrapper = new Mock<ICacheWrapper>();
 
         _allowListService = new AllowListService(
-            _mockSettingsRepository.Object,
+            _mockSettingsService.Object,
             _mockRepository.Object,
             _mockCspPermissionService.Object,
             _mockCacheWrapper.Object,
@@ -72,7 +72,7 @@ public class AllowListServiceTests
         Assert.Throws<ArgumentNullException>(() => 
         { 
             new AllowListService(
-                _mockSettingsRepository.Object, 
+                _mockSettingsService.Object, 
                 null, 
                 _mockCspPermissionService.Object, 
                 _mockCacheWrapper.Object,
@@ -87,7 +87,7 @@ public class AllowListServiceTests
         Assert.Throws<ArgumentNullException>(() => 
         { 
             new AllowListService(
-                _mockSettingsRepository.Object, 
+                _mockSettingsService.Object, 
                 _mockRepository.Object, 
                 null, 
                 _mockCacheWrapper.Object,
@@ -102,7 +102,7 @@ public class AllowListServiceTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             new AllowListService(
-                _mockSettingsRepository.Object,
+                _mockSettingsService.Object,
                 _mockRepository.Object,
                 _mockCspPermissionService.Object,
                 null,
@@ -117,7 +117,7 @@ public class AllowListServiceTests
         Assert.DoesNotThrow(() => 
         { 
             new AllowListService(
-                _mockSettingsRepository.Object, 
+                _mockSettingsService.Object, 
                 _mockRepository.Object, 
                 _mockCspPermissionService.Object, 
                 _mockCacheWrapper.Object,
@@ -130,8 +130,8 @@ public class AllowListServiceTests
     public async Task AddFromAllowListToCsp_DoesNotProcessTheAllowListWhenAllowListOptionsIsDisabled(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
 
         // Act
         await _allowListService.AddFromAllowListToCspAsync(violationSource, violationDirective);
@@ -146,8 +146,8 @@ public class AllowListServiceTests
     public async Task AddFromAllowListToCsp_DoesNotProcessTheAllowListWhenViolationSourceOrDirectiveIsNullOrEmpty(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         // Act
         await _allowListService.AddFromAllowListToCspAsync(violationSource, violationDirective);
@@ -162,8 +162,8 @@ public class AllowListServiceTests
     public async Task AddFromAllowListToCsp_WhenGivenAValidSourceAndDomainAndAllowListIsEnabled_ThenTheAllowListIsRetrieved(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
         
         _mockRepository.Setup(x => x.GetAllowListAsync(It.IsAny<string>()))
                        .ReturnsAsync(new AllowListCollection(new List<AllowListEntry>(0)));
@@ -180,8 +180,8 @@ public class AllowListServiceTests
     public async Task AddFromAllowListToCsp_WhenGivenAValidSourceAndDomainAndAnEmptyAllowList_ThenTheCspIsNotUpdated(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         _mockRepository.Setup(x => x.GetAllowListAsync(It.IsAny<string>()))
                        .ReturnsAsync(new AllowListCollection(new List<AllowListEntry>(0)));
@@ -209,8 +209,8 @@ public class AllowListServiceTests
         };
         var allowListCollection = new AllowListCollection(allowListEntries);
 
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         _mockRepository.Setup(x => x.GetAllowListAsync(It.IsAny<string>()))
                        .ReturnsAsync(allowListCollection);
@@ -243,8 +243,8 @@ public class AllowListServiceTests
         };
         var allowListCollection = new AllowListCollection(allowListEntries);
 
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         _mockRepository.Setup(x => x.GetAllowListAsync(It.IsAny<string>()))
                        .ReturnsAsync(allowListCollection);
@@ -262,8 +262,8 @@ public class AllowListServiceTests
     public async Task IsOnAllowList_ReturnsFalseWhenAllowListOptionsIsDisabled(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
 
         // Act
         var isOnAllowList = await _allowListService.IsOnAllowListAsync(violationSource, violationDirective);
@@ -277,8 +277,8 @@ public class AllowListServiceTests
     public async Task IsOnAllowList_ReturnsFalseWhenViolationSourceOrDirectiveIsNullOrEmpty(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         // Act
         var isOnAllowList = await _allowListService.IsOnAllowListAsync(violationSource, violationDirective);
@@ -292,8 +292,8 @@ public class AllowListServiceTests
     public async Task IsOnAllowList_DoesNotAttemptToGetAAllowListWhenAllowListOptionsIsDisabled(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = false });
 
         // Act
         var isOnAllowList = await _allowListService.IsOnAllowListAsync(violationSource, violationDirective);
@@ -307,8 +307,8 @@ public class AllowListServiceTests
     public async Task IsOnAllowList_DoesNotAttemptToGetAAllowListWhenViolationSourceOrDirectiveIsNullOrEmpty(string violationSource, string violationDirective)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         // Act
         var isOnAllowList = await _allowListService.IsOnAllowListAsync(violationSource, violationDirective);
@@ -322,8 +322,8 @@ public class AllowListServiceTests
     public async Task IsOnAllowList_WhenGivenAValidSourceAndDomainAndAllowListIsEnabled_ThenTheAllowListIsRetrieved(string violationSource, string directive)
     {
         // Arrange
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         // Act
         var isOnAllowList = await _allowListService.IsOnAllowListAsync(violationSource, directive);
@@ -349,8 +349,8 @@ public class AllowListServiceTests
         };
         var allowListCollection = new AllowListCollection(allowListEntries);
 
-        _mockSettingsRepository.Setup(x => x.GetAsync())
-                               .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
+        _mockSettingsService.Setup(x => x.GetAsync())
+                            .ReturnsAsync(new CspSettings { IsAllowListEnabled = true });
 
         _mockRepository.Setup(x => x.GetAllowListAsync(It.IsAny<string>()))
                        .Returns(Task.FromResult(allowListCollection));

--- a/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Cors/Provider/CustomCorsPolicyProviderTests.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading.Tasks;
 
+using EPiServer.ServiceLocation;
+
 using JetBrains.Annotations;
 
 using Microsoft.AspNetCore.Cors.Infrastructure;
@@ -29,6 +31,8 @@ public sealed class CustomCorsPolicyProviderTests
 
     private Mock<HttpContext> _mockHttpContext;
 
+    private Mock<IServiceProvider> _mockServiceProvider;
+
     private CustomCorsPolicyProvider _provider;
 
     [SetUp]
@@ -38,6 +42,11 @@ public sealed class CustomCorsPolicyProviderTests
 
         _mockService = new Mock<ICorsSettingsService>();
         _mockService.Setup(x => x.GetAsync()).ReturnsAsync(new CorsConfiguration());
+
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICorsSettingsService))).Returns(_mockService.Object);
+
+        ServiceLocator.SetServiceProvider(_mockServiceProvider.Object);
 
         _mockHttpContext = new Mock<HttpContext>();
 
@@ -52,7 +61,7 @@ public sealed class CustomCorsPolicyProviderTests
         _mockOptions = new Mock<IOptions<CorsOptions>>();
         _mockOptions.Setup(x => x.Value).Returns(corsOptions);
 
-        _provider = new CustomCorsPolicyProvider(_mockCache.Object, _mockService.Object, _mockOptions.Object);
+        _provider = new CustomCorsPolicyProvider(_mockCache.Object, _mockOptions.Object);
     }
 
     [Test]

--- a/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
@@ -1,10 +1,12 @@
 ﻿namespace Stott.Security.Optimizely.Test.Features.Header;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 using EPiServer.Core;
+using EPiServer.ServiceLocation;
 
 using Moq;
 
@@ -42,6 +44,8 @@ public sealed class HeaderCompilationServiceTests
 
     private Mock<ICacheWrapper> _cacheWrapper;
 
+    private Mock<IServiceProvider> _mockServiceProvider;
+
     private HeaderCompilationService _service;
 
     [SetUp]
@@ -65,11 +69,15 @@ public sealed class HeaderCompilationServiceTests
 
         _cacheWrapper = new Mock<ICacheWrapper>();
 
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ISecurityHeaderRepository))).Returns(_securityHeaderRepository.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICspPermissionRepository))).Returns(_cspPermissionRepository.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICspSettingsRepository))).Returns(_cspSettingsRepository.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICspSandboxRepository))).Returns(_cspSandboxRepository.Object);
+
+        ServiceLocator.SetServiceProvider(_mockServiceProvider.Object);
+
         _service = new HeaderCompilationService(
-            _cspPermissionRepository.Object,
-            _cspSettingsRepository.Object,
-            _cspSandboxRepository.Object,
-            _securityHeaderRepository.Object,
             _headerBuilder.Object,
             _mockReportUrlResolver.Object,
             _mockNonceProvider.Object,

--- a/src/Stott.Security.Optimizely.Test/Features/Nonce/DefaultNonceProviderTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Nonce/DefaultNonceProviderTests.cs
@@ -94,7 +94,7 @@ namespace Stott.Security.Optimizely.Test.Features.Nonce
             _mockCspSettingsService.Setup(x => x.Get()).Returns(new CspSettings { IsEnabled = true, IsNonceEnabled = true });
 
             _mockContext.Setup(x => x.Items)
-                        .Returns(new Dictionary<object, object?>
+                        .Returns(new Dictionary<object, object>
                         {
                             { ContentRenderingContext.ContentRenderingContextKey, renderingContext }
                         });

--- a/src/Stott.Security.Optimizely.Test/Features/Settings/Service/CspSettingsServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Settings/Service/CspSettingsServiceTests.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading.Tasks;
 
+using EPiServer.ServiceLocation;
+
 using Moq;
 
 using NUnit.Framework;
@@ -20,6 +22,8 @@ public class CspSettingsServiceTests
 
     private Mock<ICacheWrapper> _mockCache;
 
+    private Mock<IServiceProvider> _mockServiceProvider;
+
     private CspSettingsService _service;
 
     [SetUp]
@@ -29,25 +33,13 @@ public class CspSettingsServiceTests
 
         _mockCache = new Mock<ICacheWrapper>();
 
-        _service = new CspSettingsService(_mockRepository.Object, _mockCache.Object);
-    }
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICspSettingsRepository))).Returns(_mockRepository.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICacheWrapper))).Returns(_mockCache.Object);
 
-    [Test]
-    public void Constructor_ThrowsArgumentNullExceptionWhenGivenANullRepository()
-    {
-        Assert.Throws<ArgumentNullException>(() => new CspSettingsService(null, _mockCache.Object));
-    }
+        ServiceLocator.SetServiceProvider(_mockServiceProvider.Object);
 
-    [Test]
-    public void Constructor_ThrowsArgumentNullExceptionWhenGivenANullCache()
-    {
-        Assert.Throws<ArgumentNullException>(() => new CspSettingsService(_mockRepository.Object, null));
-    }
-
-    [Test]
-    public void Constructor_DoesNotThrowsAnExceptionWhenGivenAValidParameters()
-    {
-        Assert.DoesNotThrow(() => new CspSettingsService(_mockRepository.Object, _mockCache.Object));
+        _service = new CspSettingsService();
     }
 
     [Test]

--- a/src/Stott.Security.Optimizely/Entities/CspDataContext.cs
+++ b/src/Stott.Security.Optimizely/Entities/CspDataContext.cs
@@ -24,6 +24,7 @@ public class CspDataContext : DbContext, ICspDataContext
         : base(options)
     {
         _logger = logger;
+        _logger.LogInformation("CONTEXT CREATED {ID}", Guid.NewGuid());
     }
 
     public DbSet<CspSettings> CspSettings { get; set; }

--- a/src/Stott.Security.Optimizely/Entities/CspDataContext.cs
+++ b/src/Stott.Security.Optimizely/Entities/CspDataContext.cs
@@ -24,7 +24,6 @@ public class CspDataContext : DbContext, ICspDataContext
         : base(options)
     {
         _logger = logger;
-        _logger.LogInformation("CONTEXT CREATED {ID}", Guid.NewGuid());
     }
 
     public DbSet<CspSettings> CspSettings { get; set; }

--- a/src/Stott.Security.Optimizely/Features/AllowList/AllowListService.cs
+++ b/src/Stott.Security.Optimizely/Features/AllowList/AllowListService.cs
@@ -11,11 +11,11 @@ using Microsoft.Extensions.Logging;
 using Stott.Security.Optimizely.Common;
 using Stott.Security.Optimizely.Features.Caching;
 using Stott.Security.Optimizely.Features.Permissions.Service;
-using Stott.Security.Optimizely.Features.Settings.Repository;
+using Stott.Security.Optimizely.Features.Settings.Service;
 
 internal sealed class AllowListService : IAllowListService
 {
-    private readonly ICspSettingsRepository _cspSettingsRepository;
+    private readonly ICspSettingsService _cspSettingsService;
 
     private readonly IAllowListRepository _allowListRepository;
 
@@ -26,13 +26,13 @@ internal sealed class AllowListService : IAllowListService
     private readonly ILogger<IAllowListService> _logger;
 
     public AllowListService(
-        ICspSettingsRepository cspSettingsRepository,
+        ICspSettingsService cspSettingsService,
         IAllowListRepository allowListRepository,
         ICspPermissionService cspPermissionService,
         ICacheWrapper cacheWrapper,
         ILogger<IAllowListService> logger)
     {
-        _cspSettingsRepository = cspSettingsRepository ?? throw new ArgumentNullException(nameof(cspSettingsRepository));
+        _cspSettingsService = cspSettingsService ?? throw new ArgumentNullException(nameof(cspSettingsService));
         _allowListRepository = allowListRepository ?? throw new ArgumentNullException(nameof(allowListRepository));
         _cspPermissionService = cspPermissionService ?? throw new ArgumentNullException(nameof(cspPermissionService));
         _cacheWrapper = cacheWrapper ?? throw new ArgumentNullException(nameof(cacheWrapper));
@@ -41,7 +41,7 @@ internal sealed class AllowListService : IAllowListService
 
     public async Task AddFromAllowListToCspAsync(string? violationSource, string? violationDirective)
     {
-        var settings = await _cspSettingsRepository.GetAsync();
+        var settings = await _cspSettingsService.GetAsync();
         if (!settings.IsAllowListEnabled
             || string.IsNullOrWhiteSpace(violationSource)
             || string.IsNullOrWhiteSpace(violationDirective)
@@ -71,7 +71,7 @@ internal sealed class AllowListService : IAllowListService
 
     public async Task<bool> IsOnAllowListAsync(string? violationSource, string? violationDirective)
     {
-        var settings = await _cspSettingsRepository.GetAsync();
+        var settings = await _cspSettingsService.GetAsync();
         if (!settings.IsAllowListEnabled
             || string.IsNullOrWhiteSpace(violationSource)
             || string.IsNullOrWhiteSpace(violationDirective)

--- a/src/Stott.Security.Optimizely/Features/Caching/CacheWrapper.cs
+++ b/src/Stott.Security.Optimizely/Features/Caching/CacheWrapper.cs
@@ -32,7 +32,7 @@ public sealed class CacheWrapper : ICacheWrapper
         try
         {
             var evictionPolicy = new CacheEvictionPolicy(
-                TimeSpan.FromHours(1),
+                TimeSpan.FromHours(12),
                 CacheTimeoutType.Absolute,
                 Enumerable.Empty<string>(),
                 new[] { MasterKey });

--- a/src/Stott.Security.Optimizely/Features/Cors/Provider/CustomCorsPolicyProvider.cs
+++ b/src/Stott.Security.Optimizely/Features/Cors/Provider/CustomCorsPolicyProvider.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading.Tasks;
 
+using EPiServer.ServiceLocation;
+
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
@@ -15,18 +17,14 @@ public sealed class CustomCorsPolicyProvider : DefaultCorsPolicyProvider, ICorsP
 {
     private readonly ICacheWrapper _cache;
 
-    private readonly ICorsSettingsService _service;
-
     private const string CacheKey = "stott.security.cors.config";
 
     public CustomCorsPolicyProvider(
         ICacheWrapper cache, 
-        ICorsSettingsService service,
         IOptions<CorsOptions> corsOptions)
         : base(corsOptions)
     {
         _cache = cache;
-        _service = service;
     }
 
     public new async Task<CorsPolicy?> GetPolicyAsync(HttpContext context, string? policyName)
@@ -57,10 +55,10 @@ public sealed class CustomCorsPolicyProvider : DefaultCorsPolicyProvider, ICorsP
         return policy;
     }
 
-    private async Task<CorsPolicy> LoadPolicy()
+    private static async Task<CorsPolicy> LoadPolicy()
     {
-        var configuration = await _service.GetAsync();
-
+        var service = ServiceLocator.Current.GetInstance<ICorsSettingsService>();
+        var configuration = await service.GetAsync();
         var policy = new CorsPolicy();
 
         if (!configuration.IsEnabled)

--- a/src/Stott.Security.Optimizely/Features/Settings/ICspSettings.cs
+++ b/src/Stott.Security.Optimizely/Features/Settings/ICspSettings.cs
@@ -20,7 +20,7 @@ public interface ICspSettings
 
     bool UseExternalReporting { get; }
 
-    string ExternalReportToUrl { get; }
+    string? ExternalReportToUrl { get; }
 
-    string ExternalReportUriUrl { get; }
+    string? ExternalReportUriUrl { get; }
 }


### PR DESCRIPTION
- Updated the CspSettingsService to lazy load it's dependencies and to retrieve CSP Settings from Cache before the database.
- Updated the AllowListService to consume CspSettingsService instead of CspSettingsRepository.  This means it will essentially check the cached settings instead of making a DB call twice per reported CSP violation.
- Increased default cache duration from 1h to 12h
- Updated the CustomCorsPolicyProvider to lazy load dependencies which access the database.  This primarily uses a cached compiled policy anyway.

This results in a drastic reduction of the number of times the DBContext is created.
This reduces the number of DB calls made to retrieve settings to understand the configuration of the system.