### PR TITLE
Handle CSP being too large

### DIFF
--- a/Sample/OptiNetNine/Views/Shared/_Layout.cshtml
+++ b/Sample/OptiNetNine/Views/Shared/_Layout.cshtml
@@ -9,10 +9,8 @@
 <head>
     @await Component.InvokeAsync("MetaData", new { sitePage = Model.CurrentPage })
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" integrity="sha256-zzPh8NflvEInFbVSzLYGVMLOn0j0kfsjq/UlNeMBRYw=" crossorigin="anonymous">
     <link rel="stylesheet" asp-href-include="~/*.css" />
-
     <style nonce="">
         body {
             padding-top: 3.5rem;
@@ -42,11 +40,10 @@
 
     @RenderBody()
 
-    <script nonce src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+    <script nonce src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha256-ORBCb//WwUWwNh+EjsvO97snO3mAJ1+jhMzrlPBTYSQ=" crossorigin="anonymous"></script>
     <script nonce asp-src-include="~/*.js"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
     @Html.RequiredClientResources(RenderingTags.Footer)
-    
 </body>
 </html>

--- a/src/Stott.Security.Optimizely.Test/Features/Csp/CspOptimizerTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/CspOptimizerTests.cs
@@ -1,0 +1,569 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Stott.Security.Optimizely.Common;
+using Stott.Security.Optimizely.Features.Csp;
+using Stott.Security.Optimizely.Features.Csp.Dtos;
+
+namespace Stott.Security.Optimizely.Test.Features.Csp;
+
+[TestFixture]
+public sealed class CspOptimizerTests
+{
+    [Test]
+    public void GivenScriptSourcesDoNotExceedMaxHeaderSize_ThenScriptSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 100).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ScriptSource, sources),
+            new(CspConstants.Directives.ScriptSourceElement, sources),
+            new(CspConstants.Directives.ScriptSourceAttribute, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var scriptsGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ScriptSource)));
+
+        // Assert
+        Assert.That(scriptsGroup, Has.Count.EqualTo(3));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSource)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSourceElement)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSourceAttribute)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenScriptSourcesDoNotExceedMaxHeaderSizeAndThereIsAReportTo_ThenScriptSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 100).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ScriptSource, sources),
+            new(CspConstants.Directives.ScriptSourceElement, sources),
+            new(CspConstants.Directives.ScriptSourceAttribute, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var scriptsGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ScriptSource)));
+
+        // Assert
+        Assert.That(scriptsGroup, Has.Count.EqualTo(4));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSource)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSourceElement)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSourceAttribute)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenScriptSourcesExceedMaxHeaderSize_ThenScriptSourcesShouldBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ScriptSource, sources),
+            new(CspConstants.Directives.ScriptSourceElement, sources),
+            new(CspConstants.Directives.ScriptSourceAttribute, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var scriptsGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ScriptSource)));
+
+        // Assert
+        Assert.That(scriptsGroup, Has.Count.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSource)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenScriptSourcesExceedMaxHeaderSizeAndThereIsAReportTo_ThenScriptSourcesShouldBeSimplifiedToScriptSrcAndReportTo()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ScriptSource, sources),
+            new(CspConstants.Directives.ScriptSourceElement, sources),
+            new(CspConstants.Directives.ScriptSourceAttribute, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var scriptsGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ScriptSource)));
+
+        // Assert
+        Assert.That(scriptsGroup, Has.Count.EqualTo(2));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ScriptSource)), Is.EqualTo(1));
+        Assert.That(scriptsGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStyleSourcesDoNotExceedMaxHeaderSize_ThenStyleSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 100).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.StyleSource, sources),
+            new(CspConstants.Directives.StyleSourceElement, sources),
+            new(CspConstants.Directives.StyleSourceAttribute, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var styleGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.StyleSource)));
+
+        // Assert
+        Assert.That(styleGroup, Has.Count.EqualTo(3));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSource)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSourceElement)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSourceAttribute)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStyleSourcesDoNotExceedMaxHeaderSizeAndThereIsAReportTo_ThenStyleSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 100).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.StyleSource, sources),
+            new(CspConstants.Directives.StyleSourceElement, sources),
+            new(CspConstants.Directives.StyleSourceAttribute, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var styleGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.StyleSource)));
+
+        // Assert
+        Assert.That(styleGroup, Has.Count.EqualTo(4));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSource)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSourceElement)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSourceAttribute)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStyleSourcesExceedMaxHeaderSize_ThenStyleSourcesShouldBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.StyleSource, sources),
+            new(CspConstants.Directives.StyleSourceElement, sources),
+            new(CspConstants.Directives.StyleSourceAttribute, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var styleGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.StyleSource)));
+
+        // Assert
+        Assert.That(styleGroup, Has.Count.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSource)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStyleSourcesExceedMaxHeaderSizeAndThereIsAReportTo_ThenStyleSourcesShouldBeSimplifiedToStyleSrcAndReportTo()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.StyleSource, sources),
+            new(CspConstants.Directives.StyleSourceElement, sources),
+            new(CspConstants.Directives.StyleSourceAttribute, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var styleGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.StyleSource)));
+
+        // Assert
+        Assert.That(styleGroup, Has.Count.EqualTo(2));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.StyleSource)), Is.EqualTo(1));
+        Assert.That(styleGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenFrameSourcesDoNotExceedMaxHeaderSize_ThenFrameSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 70).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.FencedFrameSource, sources),
+            new(CspConstants.Directives.FrameSource, sources),
+            new(CspConstants.Directives.ChildSource, sources),
+            new(CspConstants.Directives.WorkerSource, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var frameGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ChildSource)));
+
+        // Assert
+        Assert.That(frameGroup, Has.Count.EqualTo(4));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FencedFrameSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FrameSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ChildSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.WorkerSource)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenFrameSourcesDoNotExceedMaxHeaderSizeAndThereIsAReportTo_ThenFrameSourcesShouldNotBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 70).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.FencedFrameSource, sources),
+            new(CspConstants.Directives.FrameSource, sources),
+            new(CspConstants.Directives.ChildSource, sources),
+            new(CspConstants.Directives.WorkerSource, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var frameGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ChildSource)));
+
+        // Assert
+        Assert.That(frameGroup, Has.Count.EqualTo(5));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FencedFrameSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FrameSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ChildSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.WorkerSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenFrameSourcesExceedMaxHeaderSize_ThenFrameSourcesShouldBeSimplified()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.FencedFrameSource, sources),
+            new(CspConstants.Directives.FrameSource, sources),
+            new(CspConstants.Directives.ChildSource, sources),
+            new(CspConstants.Directives.WorkerSource, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var frameGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ChildSource)));
+
+        // Assert
+        Assert.That(frameGroup, Has.Count.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ChildSource)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenFrameSourcesExceedMaxHeaderSizeAndThereIsAReportTo_ThenFrameSourcesShouldBeSimplifiedToChildSrcAndReportTo()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.StyleSource, sources),
+            new(CspConstants.Directives.StyleSourceElement, sources),
+            new(CspConstants.Directives.StyleSourceAttribute, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var frameGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ChildSource)));
+
+        // Assert
+        Assert.That(frameGroup, Has.Count.EqualTo(2));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ChildSource)), Is.EqualTo(1));
+        Assert.That(frameGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenOtherFetchSourcesDoNotExceedMaxHeaderSize_ThenOtherFetchSourcesWillNotBeSplitIntoSeparateGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 50).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ConnectSource, sources),
+            new(CspConstants.Directives.FontSource, sources),
+            new(CspConstants.Directives.ImageSource, sources),
+            new(CspConstants.Directives.ManifestSource, sources),
+            new(CspConstants.Directives.MediaSource, sources),
+            new(CspConstants.Directives.ObjectSource, sources),
+            new(CspConstants.Directives.PreFetchSource, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ConnectSource)));
+
+        // Assert
+        Assert.That(otherGroup, Has.Count.EqualTo(7));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ConnectSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FontSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ImageSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ManifestSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.MediaSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ObjectSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.PreFetchSource)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenOtherFetchSourcesDoNotExceedMaxHeaderSizeAndReportToExists_ThenOtherFetchSourcesWillNotBeSplitIntoSeparateGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 50).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ConnectSource, sources),
+            new(CspConstants.Directives.FontSource, sources),
+            new(CspConstants.Directives.ImageSource, sources),
+            new(CspConstants.Directives.ManifestSource, sources),
+            new(CspConstants.Directives.MediaSource, sources),
+            new(CspConstants.Directives.ObjectSource, sources),
+            new(CspConstants.Directives.PreFetchSource, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.ConnectSource)));
+
+        // Assert
+        Assert.That(otherGroup, Has.Count.EqualTo(8));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ConnectSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FontSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ImageSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ManifestSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.MediaSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ObjectSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.PreFetchSource)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenOtherFetchSourcesExceedMaxHeaderSize_ThenOtherFetchSourcesShouldBeSplitAcrossMultipleGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ConnectSource, sources),
+            new(CspConstants.Directives.FontSource, sources),
+            new(CspConstants.Directives.ImageSource, sources),
+            new(CspConstants.Directives.ManifestSource, sources),
+            new(CspConstants.Directives.MediaSource, sources),
+            new(CspConstants.Directives.ObjectSource, sources),
+            new(CspConstants.Directives.PreFetchSource, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroups = result.Where(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ConnectSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.FontSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ImageSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ManifestSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.MediaSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ObjectSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.PreFetchSource))).ToList();
+
+        // Assert
+        Assert.That(result, Has.Count.GreaterThan(5));
+        Assert.That(otherGroups, Has.Count.GreaterThan(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ConnectSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FontSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ImageSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ManifestSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.MediaSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ObjectSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.PreFetchSource))), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenOtherFetchSourcesExceedMaxHeaderSizeWithReportTo_ThenOtherFetchSourcesShouldBeSplitAcrossMultipleGroupsEachWithReportTo()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.ConnectSource, sources),
+            new(CspConstants.Directives.FontSource, sources),
+            new(CspConstants.Directives.ImageSource, sources),
+            new(CspConstants.Directives.ManifestSource, sources),
+            new(CspConstants.Directives.MediaSource, sources),
+            new(CspConstants.Directives.ObjectSource, sources),
+            new(CspConstants.Directives.PreFetchSource, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroups = result.Where(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ConnectSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.FontSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ImageSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ManifestSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.MediaSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.ObjectSource))
+                                         || x.Any(y => y.Directive.Equals(CspConstants.Directives.PreFetchSource))).ToList();
+
+        // Assert
+        Assert.That(result, Has.Count.GreaterThan(5));
+        Assert.That(otherGroups, Has.Count.GreaterThan(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ConnectSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FontSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ImageSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ManifestSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.MediaSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ObjectSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.PreFetchSource))), Is.EqualTo(1));
+        Assert.That(otherGroups.All(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ReportTo))), Is.True);
+    }
+
+    [Test]
+    public void GivenStandAloneDirectivesDoNotExceedHeaderSize_ThenStandAloneSourcesWillNotBeSplitIntoSeparateGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 50).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.BaseUri, sources),
+            new(CspConstants.Directives.FormAction, sources),
+            new(CspConstants.Directives.NavigateTo, sources),
+            new(CspConstants.Directives.FrameAncestors, sources),
+            new(CspConstants.Directives.UpgradeInsecureRequests, sources),
+            new(CspConstants.Directives.Sandbox, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.BaseUri)));
+
+        // Assert
+        Assert.That(otherGroup, Has.Count.EqualTo(6));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.BaseUri)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FormAction)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.NavigateTo)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FrameAncestors)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.Sandbox)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStandAloneDirectivesDoNotExceedHeaderSizeWithReportTo_ThenStandAloneSourcesWillNotBeSplitIntoSeparateGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 50).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.BaseUri, sources),
+            new(CspConstants.Directives.FormAction, sources),
+            new(CspConstants.Directives.NavigateTo, sources),
+            new(CspConstants.Directives.FrameAncestors, sources),
+            new(CspConstants.Directives.UpgradeInsecureRequests, sources),
+            new(CspConstants.Directives.Sandbox, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var otherGroup = result.FirstOrDefault(x => x.Any(y => y.Directive.StartsWith(CspConstants.Directives.BaseUri)));
+
+        // Assert
+        Assert.That(otherGroup, Has.Count.EqualTo(7));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.BaseUri)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FormAction)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.NavigateTo)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.FrameAncestors)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.Sandbox)), Is.EqualTo(1));
+        Assert.That(otherGroup.Count(x => x.Directive.Equals(CspConstants.Directives.ReportTo)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStandAloneDirectivesDoExceedHeaderSize_ThenStandAloneSourcesWillBeSplitIntoSeparateGroups()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.BaseUri, sources),
+            new(CspConstants.Directives.FormAction, sources),
+            new(CspConstants.Directives.NavigateTo, sources),
+            new(CspConstants.Directives.FrameAncestors, sources),
+            new(CspConstants.Directives.UpgradeInsecureRequests, sources),
+            new(CspConstants.Directives.Sandbox, sources)
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var standAloneGroups = result.Where(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.BaseUri))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.FormAction))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.NavigateTo))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.FrameAncestors))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.Sandbox))).ToList();
+
+        // Assert
+        Assert.That(result, Has.Count.GreaterThan(5));
+        Assert.That(standAloneGroups, Has.Count.GreaterThan(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.BaseUri))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FormAction))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.NavigateTo))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FrameAncestors))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.Sandbox))), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GivenStandAloneDirectivesDoExceedHeaderSizeWithReportTo_ThenStandAloneSourcesWillBeSplitIntoSeparateGroupsEachWithReportTo()
+    {
+        // Arrange
+        var sources = Enumerable.Range(0, 250).Select(i => $"https://{i}.example.com").ToList();
+        var directives = new List<CspDirectiveDto>
+        {
+            new(CspConstants.Directives.BaseUri, sources),
+            new(CspConstants.Directives.FormAction, sources),
+            new(CspConstants.Directives.NavigateTo, sources),
+            new(CspConstants.Directives.FrameAncestors, sources),
+            new(CspConstants.Directives.UpgradeInsecureRequests, sources),
+            new(CspConstants.Directives.Sandbox, sources),
+            new(CspConstants.Directives.ReportTo, "report-url-header")
+        };
+
+        // Act
+        var result = CspOptimizer.GroupDirectives(directives);
+        var standAloneGroups = result.Where(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.BaseUri))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.FormAction))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.NavigateTo))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.FrameAncestors))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests))
+                                              || x.Any(y => y.Directive.Equals(CspConstants.Directives.Sandbox))).ToList();
+
+        // Assert
+        Assert.That(result, Has.Count.GreaterThan(5));
+        Assert.That(standAloneGroups, Has.Count.GreaterThan(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.BaseUri))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FormAction))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.NavigateTo))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.FrameAncestors))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.UpgradeInsecureRequests))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.Count(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.Sandbox))), Is.EqualTo(1));
+        Assert.That(standAloneGroups.All(x => x.Any(y => y.Directive.Equals(CspConstants.Directives.ReportTo))), Is.True);
+    }
+}

--- a/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
@@ -212,8 +212,8 @@ public sealed class CspServiceTests
         var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
-        Assert.That(actualHeader.Value.Contains("report-to"), Is.True);
-        Assert.That(actualHeader.Value.Contains("report-uri"), Is.True);
+        Assert.That(actualHeader.Value.Contains(CspConstants.Directives.ReportTo), Is.True);
+        Assert.That(actualHeader.Value.Contains(CspConstants.Directives.ReportUri), Is.True);
     }
 
     [Test]
@@ -233,8 +233,8 @@ public sealed class CspServiceTests
         var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
-        Assert.That(actualHeader.Value.Contains("report-to"), Is.True);
-        Assert.That(actualHeader.Value.Contains("report-uri https://www.example.com"), Is.True);
+        Assert.That(actualHeader.Value.Contains(CspConstants.Directives.ReportTo), Is.True);
+        Assert.That(actualHeader.Value.Contains($"{CspConstants.Directives.ReportUri} https://www.example.com"), Is.True);
     }
 
     [Test]

--- a/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
@@ -73,7 +73,7 @@ public sealed class CspServiceTests
     {
         // Arrange
         SetupCspSettings(true);
-        _mockPermissionService.Setup(x => x.GetAsync()).ReturnsAsync(new List<CspSource>());
+        _mockPermissionService.Setup(x => x.GetAsync()).ReturnsAsync([]);
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
@@ -88,7 +88,7 @@ public sealed class CspServiceTests
         // Arrange
         SetupCspSettings(true);
         _mockPermissionService.Setup(x => x.GetAsync()).ReturnsAsync((IList<CspSource>)null);
-        _mockPage.Setup(x => x.ContentSecurityPolicySources).Returns(new List<PageCspSourceMapping>(0));
+        _mockPage.Setup(x => x.ContentSecurityPolicySources).Returns([]);
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
@@ -102,8 +102,8 @@ public sealed class CspServiceTests
     {
         // Arrange
         SetupCspSettings(true);
-        _mockPermissionService.Setup(x => x.GetAsync()).ReturnsAsync(new List<CspSource>());
-        _mockPage.Setup(x => x.ContentSecurityPolicySources).Returns(new List<PageCspSourceMapping>(0));
+        _mockPermissionService.Setup(x => x.GetAsync()).ReturnsAsync([]);
+        _mockPage.Setup(x => x.ContentSecurityPolicySources).Returns([]);
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
@@ -124,7 +124,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var cspHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var cspHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(cspHeader, Is.Not.Null);
@@ -143,7 +143,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var cspHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var cspHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(cspHeader, Is.Not.Null);
@@ -167,7 +167,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
         var expectedHeader = "default-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-hashes' 'inline-speculation-rules' blob: data: filesystem: http: https: ws: wss: mediastream: https://www.example.com;";
 
         // Assert
@@ -188,7 +188,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
         var expectedHeader = "default-src https://www.example.com;";
 
         // Assert
@@ -209,7 +209,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.First(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(actualHeader.Value.Contains("report-to"), Is.True);
@@ -230,7 +230,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.First(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(actualHeader.Value.Contains("report-to"), Is.True);
@@ -252,8 +252,8 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
-        var actualHeaderValue = actualHeader.Value ?? string.Empty;
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
         Assert.That(actualHeaderValue.Contains(CspConstants.Directives.Sandbox), Is.False);
@@ -278,8 +278,8 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
-        var actualHeaderValue = actualHeader.Value ?? string.Empty;
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
         Assert.That(actualHeaderValue.Contains(CspConstants.Directives.Sandbox), Is.False);
@@ -296,15 +296,11 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
-        var actualHeaderValue = actualHeader.Value ?? string.Empty;
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
-        Assert.Multiple(() =>
-        {
-            Assert.That(actualHeaderValue, Is.Not.Null);
-            Assert.That(actualHeaderValue.Contains(CspConstants.Directives.Sandbox), Is.False);
-        });
+        Assert.That(actualHeaderValue.Contains(CspConstants.Directives.Sandbox), Is.False);
     }
 
     [Test]
@@ -352,7 +348,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert
@@ -382,7 +378,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert
@@ -397,8 +393,8 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
-        var actualHeaderValue = actualHeader.Value ?? string.Empty;
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
         Assert.That(actualHeaderValue.Contains(CspConstants.Directives.UpgradeInsecureRequests), Is.False);
@@ -412,8 +408,8 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
-        var actualHeaderValue = actualHeader.Value ?? string.Empty;
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
         Assert.That(actualHeaderValue.Contains(CspConstants.Directives.UpgradeInsecureRequests), Is.False);
@@ -427,7 +423,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert

--- a/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
@@ -124,7 +124,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var cspHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var cspHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(cspHeader, Is.Not.Null);
@@ -143,7 +143,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var cspHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var cspHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(cspHeader, Is.Not.Null);
@@ -167,7 +167,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
         var expectedHeader = "default-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-hashes' 'inline-speculation-rules' blob: data: filesystem: http: https: ws: wss: mediastream: https://www.example.com;";
 
         // Assert
@@ -188,7 +188,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
         var expectedHeader = "default-src https://www.example.com;";
 
         // Assert
@@ -209,7 +209,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.First(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(actualHeader.Value.Contains(CspConstants.Directives.ReportTo), Is.True);
@@ -230,7 +230,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.First(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.First(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
 
         // Assert
         Assert.That(actualHeader.Value.Contains(CspConstants.Directives.ReportTo), Is.True);
@@ -252,7 +252,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy);
         var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
@@ -278,7 +278,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
@@ -296,7 +296,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
@@ -348,7 +348,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert
@@ -378,7 +378,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert
@@ -393,7 +393,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
@@ -408,7 +408,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader?.Value ?? string.Empty;
 
         // Assert
@@ -423,7 +423,7 @@ public sealed class CspServiceTests
 
         // Act
         var policy = await _cspService.GetCompiledHeaders(null);
-        var actualHeader = policy.FirstOrDefault(x => x.Name == CspConstants.HeaderNames.ContentSecurityPolicy || x.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
+        var actualHeader = policy.FirstOrDefault(x => x.Key == CspConstants.HeaderNames.ContentSecurityPolicy || x.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy);
         var actualHeaderValue = actualHeader.Value ?? string.Empty;
 
         // Assert

--- a/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
@@ -17,6 +17,7 @@ using Stott.Security.Optimizely.Features.Csp;
 using Stott.Security.Optimizely.Features.Csp.Nonce;
 using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.Pages;
+using Stott.Security.Optimizely.Features.PermissionPolicy.Service;
 using Stott.Security.Optimizely.Features.SecurityHeaders.Service;
 
 [TestFixture]
@@ -29,6 +30,10 @@ public sealed class HeaderCompilationServiceTests
     private Mock<INonceProvider> _mockNonceProvider;
 
     private Mock<ICacheWrapper> _cacheWrapper;
+
+    private Mock<ICspService> _mockCspService;
+
+    private Mock<IPermissionPolicyService> _mockPermissionPolicyService;
 
     private Mock<IServiceProvider> _mockServiceProvider;
 
@@ -46,8 +51,14 @@ public sealed class HeaderCompilationServiceTests
 
         _cacheWrapper = new Mock<ICacheWrapper>();
 
+        _mockCspService = new Mock<ICspService>();
+
+        _mockPermissionPolicyService = new Mock<IPermissionPolicyService>();
+
         _mockServiceProvider = new Mock<IServiceProvider>();
         _mockServiceProvider.Setup(x => x.GetService(typeof(ISecurityHeaderService))).Returns(_securityHeaderService.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICspService))).Returns(_mockCspService.Object);
+        _mockServiceProvider.Setup(x => x.GetService(typeof(IPermissionPolicyService))).Returns(_mockPermissionPolicyService.Object);
 
         ServiceLocator.SetServiceProvider(_mockServiceProvider.Object);
 
@@ -62,9 +73,9 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new Dictionary<string, string> { { "HeaderOne", "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
 
-        _cacheWrapper.Setup(x => x.Get<Dictionary<string, string>>(It.IsAny<string>()))
+        _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
                      .Callback<string>(x => cacheKeyUsed = x);
 
@@ -80,10 +91,10 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new Dictionary<string, string> { { "HeaderOne", "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<PageData>(MockBehavior.Loose);
 
-        _cacheWrapper.Setup(x => x.Get<Dictionary<string, string>>(It.IsAny<string>()))
+        _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
                      .Callback<string>(x => cacheKeyUsed = x);
 
@@ -99,11 +110,11 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new Dictionary<string, string> { { "HeaderOne", "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<TestPageData>(MockBehavior.Loose);
         mockPageData.Setup(x => x.ContentSecurityPolicySources).Returns((IList<PageCspSourceMapping>)null);
 
-        _cacheWrapper.Setup(x => x.Get<Dictionary<string, string>>(It.IsAny<string>()))
+        _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
                      .Callback<string>(x => cacheKeyUsed = x);
 
@@ -119,11 +130,11 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new Dictionary<string, string> { { "HeaderOne", "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<TestPageData>(MockBehavior.Loose);
         mockPageData.Setup(x => x.ContentSecurityPolicySources).Returns(new List<PageCspSourceMapping>(0));
 
-        _cacheWrapper.Setup(x => x.Get<Dictionary<string, string>>(It.IsAny<string>()))
+        _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
                      .Callback<string>(x => cacheKeyUsed = x);
 
@@ -139,7 +150,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new Dictionary<string, string> { { "HeaderOne", "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
 
         var pageSources = new List<PageCspSourceMapping>
         {
@@ -149,7 +160,7 @@ public sealed class HeaderCompilationServiceTests
         var mockPageData = new Mock<TestPageData>(MockBehavior.Loose);
         mockPageData.Setup(x => x.ContentSecurityPolicySources).Returns(pageSources);
 
-        _cacheWrapper.Setup(x => x.Get<Dictionary<string, string>>(It.IsAny<string>()))
+        _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
                      .Callback<string>(x => cacheKeyUsed = x);
 

--- a/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Header/HeaderCompilationServiceTests.cs
@@ -73,7 +73,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Key = "HeaderOne", Value = "HeaderOneValues" } };
 
         _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
                      .Returns(headers)
@@ -91,7 +91,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Key = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<PageData>(MockBehavior.Loose);
 
         _cacheWrapper.Setup(x => x.Get<List<HeaderDto>>(It.IsAny<string>()))
@@ -110,7 +110,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Key = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<TestPageData>(MockBehavior.Loose);
         mockPageData.Setup(x => x.ContentSecurityPolicySources).Returns((IList<PageCspSourceMapping>)null);
 
@@ -130,7 +130,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Key = "HeaderOne", Value = "HeaderOneValues" } };
         var mockPageData = new Mock<TestPageData>(MockBehavior.Loose);
         mockPageData.Setup(x => x.ContentSecurityPolicySources).Returns(new List<PageCspSourceMapping>(0));
 
@@ -150,7 +150,7 @@ public sealed class HeaderCompilationServiceTests
     {
         // Arrange
         string cacheKeyUsed = null;
-        var headers = new List<HeaderDto> { new HeaderDto { Name = "HeaderOne", Value = "HeaderOneValues" } };
+        var headers = new List<HeaderDto> { new HeaderDto { Key = "HeaderOne", Value = "HeaderOneValues" } };
 
         var pageSources = new List<PageCspSourceMapping>
         {

--- a/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using NUnit.Framework;
 
 using Stott.Security.Optimizely.Features.Caching;
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.PermissionPolicy;
 using Stott.Security.Optimizely.Features.PermissionPolicy.Models;
 using Stott.Security.Optimizely.Features.PermissionPolicy.Repository;
@@ -233,7 +234,7 @@ public sealed class PermissionPolicyServiceTests
     public async Task GetCompiledHeaders_GivenCacheHasCompiledHeaders_ThenHeadersAreReturnedFromCacheAndNotTheRepository()
     {
         // Arrange
-        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = new List<string> { "Test" } });
+        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = ["Test"] });
 
         // Act
         var result = await _service.GetCompiledHeaders();
@@ -264,7 +265,7 @@ public sealed class PermissionPolicyServiceTests
     {
         // Arrange
         _mockRepository.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PermissionPolicySettingsModel { IsEnabled = true });
-        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(new List<string> { "Test" });
+        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(["Test"]);
 
         // Act
         var result = await _service.GetCompiledHeaders();
@@ -293,7 +294,7 @@ public sealed class PermissionPolicyServiceTests
     public async Task GetCompiledHeaders_GivenCachedDataIsEnabledButThereAreNoDirectives_ThenNoHeadersAreReturned()
     {
         // Arrange
-        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = new List<string>()});
+        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = []});
 
         // Act
         var result = await _service.GetCompiledHeaders();
@@ -306,21 +307,21 @@ public sealed class PermissionPolicyServiceTests
     public async Task GetCompiledHeaders_GivenCachedDataIsEnabled_ThenHeadersAreReturned()
     {
         // Arrange
-        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = new List<string> { "Test" } });
+        _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(new CompiledPermissionPolicy { IsEnabled = true, Directives = ["Test"] });
 
         // Act
         var result = await _service.GetCompiledHeaders();
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<KeyValuePair<string, string>>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
     }
 
     [Test]
     public async Task GetCompiledHeaders_GivenCachedDataIsEnabledAndTwoDirectivesExist_ThenHeadersAreReturned()
     {
         // Arrange
-        var cachedData = new CompiledPermissionPolicy { IsEnabled = true, Directives = new List<string> { "Test", "Example" } };
+        var cachedData = new CompiledPermissionPolicy { IsEnabled = true, Directives = ["Test", "Example"] };
         _mockCache.Setup(x => x.Get<CompiledPermissionPolicy>(It.IsAny<string>())).Returns(cachedData);
 
         // Act
@@ -328,7 +329,7 @@ public sealed class PermissionPolicyServiceTests
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<KeyValuePair<string, string>>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
     }
 
     [Test]
@@ -349,7 +350,7 @@ public sealed class PermissionPolicyServiceTests
     {
         // Arrange
         _mockRepository.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PermissionPolicySettingsModel { IsEnabled = true });
-        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(new List<string>());
+        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync([]);
 
         // Act
         var result = await _service.GetCompiledHeaders();
@@ -363,14 +364,14 @@ public sealed class PermissionPolicyServiceTests
     {
         // Arrange
         _mockRepository.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PermissionPolicySettingsModel { IsEnabled = true });
-        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(new List<string> { "Test" });
+        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(["Test"]);
 
         // Act
         var result = await _service.GetCompiledHeaders();
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<KeyValuePair<string, string>>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
     }
 
     [Test]
@@ -378,13 +379,13 @@ public sealed class PermissionPolicyServiceTests
     {
         // Arrange
         _mockRepository.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PermissionPolicySettingsModel { IsEnabled = true });
-        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(new List<string> { "Test", "Example" });
+        _mockRepository.Setup(x => x.ListDirectiveFragments()).ReturnsAsync(["Test", "Example"]);
 
         // Act
         var result = await _service.GetCompiledHeaders();
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<KeyValuePair<string, string>>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
     }
 }

--- a/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
@@ -120,6 +120,11 @@ public sealed class PermissionPolicyServiceTests
         var random = new Random();
         var policyOneIndex = random.Next(0, PermissionPolicyConstants.AllDirectives.Count - 1);
         var policyTwoIndex = random.Next(0, PermissionPolicyConstants.AllDirectives.Count - 1);
+        while (policyOneIndex == policyTwoIndex)
+        {
+            policyTwoIndex = random.Next(0, PermissionPolicyConstants.AllDirectives.Count - 1);
+        }
+
         var directives = new List<PermissionPolicyDirectiveModel>
         {
             new() {

--- a/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/PermissionPolicy/Services/PermissionPolicyServiceTests.cs
@@ -314,7 +314,7 @@ public sealed class PermissionPolicyServiceTests
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
     }
 
     [Test]
@@ -329,7 +329,7 @@ public sealed class PermissionPolicyServiceTests
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
     }
 
     [Test]
@@ -371,7 +371,7 @@ public sealed class PermissionPolicyServiceTests
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test"));
     }
 
     [Test]
@@ -386,6 +386,6 @@ public sealed class PermissionPolicyServiceTests
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Name == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
+        Assert.That(result, Has.Some.Matches<HeaderDto>(x => x.Key == PermissionPolicyConstants.PermissionPolicyHeader && x.Value == "Test, Example"));
     }
 }

--- a/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTestCases.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTestCases.cs
@@ -67,10 +67,10 @@ public static class SecurityHeaderServiceTestCases
     {
         get
         {
-            yield return new TestCaseData(true, 200000, true, true, "max-age=200000; includeSubDomains");
-            yield return new TestCaseData(true, 150000, false, true, "max-age=150000");
-            yield return new TestCaseData(false, 150000, false, false, null);
-            yield return new TestCaseData(false, 150000, true, false, null);
+            yield return new TestCaseData(true, 200000, true, "max-age=200000; includeSubDomains");
+            yield return new TestCaseData(true, 150000, false, "max-age=150000");
+            yield return new TestCaseData(false, 150000, false, null);
+            yield return new TestCaseData(false, 150000, true, null);
         }
     }
 }

--- a/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTests.cs
@@ -286,14 +286,14 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.XssProtection)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.FrameOptions)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.StrictTransportSecurity)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.XssProtection)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.FrameOptions)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.StrictTransportSecurity)), Is.False);
     }
 
     [Test]
@@ -308,7 +308,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.EqualTo(shouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.EqualTo(shouldExist));
     }
 
     [Test]
@@ -323,7 +323,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.XssProtection)), Is.EqualTo(shouldHeaderExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.XssProtection)), Is.EqualTo(shouldHeaderExist));
     }
 
     [Test]
@@ -338,7 +338,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -353,7 +353,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.FrameOptions)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.FrameOptions)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -368,7 +368,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -383,7 +383,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -398,7 +398,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -416,7 +416,7 @@ public sealed class SecurityHeaderServiceTests
 
         // Act
         var headers = await _service.GetCompiledHeaders();
-        var header = headers.FirstOrDefault(x => x.Name.Equals(CspConstants.HeaderNames.StrictTransportSecurity));
+        var header = headers.FirstOrDefault(x => x.Key.Equals(CspConstants.HeaderNames.StrictTransportSecurity));
 
         // Assert
         Assert.That(header?.Value, Is.EqualTo(expectedValue));

--- a/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/SecurityHeaders/Service/SecurityHeaderServiceTests.cs
@@ -286,14 +286,14 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.XssProtection)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.FrameOptions)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.False);
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.StrictTransportSecurity)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.XssProtection)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.FrameOptions)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.False);
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.StrictTransportSecurity)), Is.False);
     }
 
     [Test]
@@ -308,7 +308,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.EqualTo(shouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ContentTypeOptions)), Is.EqualTo(shouldExist));
     }
 
     [Test]
@@ -323,7 +323,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.XssProtection)), Is.EqualTo(shouldHeaderExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.XssProtection)), Is.EqualTo(shouldHeaderExist));
     }
 
     [Test]
@@ -338,7 +338,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.ReferrerPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -353,7 +353,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.FrameOptions)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.FrameOptions)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -368,7 +368,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginEmbedderPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -383,7 +383,7 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginOpenerPolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
@@ -398,12 +398,12 @@ public sealed class SecurityHeaderServiceTests
         var headers = await _service.GetCompiledHeaders();
 
         // Assert
-        Assert.That(headers.Any(x => x.Key.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.EqualTo(headerShouldExist));
+        Assert.That(headers.Any(x => x.Name.Equals(CspConstants.HeaderNames.CrossOriginResourcePolicy)), Is.EqualTo(headerShouldExist));
     }
 
     [Test]
     [TestCaseSource(typeof(SecurityHeaderServiceTestCases), nameof(SecurityHeaderServiceTestCases.GetStrictTransportSecurityTestCases))]
-    public async Task GetCompiledHeaders_CorrectlySetsTheStrictTransportSecurityHeaderWhenEnabled(bool isEnabled, int maxAge, bool includeSubdomains, bool shouldExist, string expectedValue)
+    public async Task GetCompiledHeaders_CorrectlySetsTheStrictTransportSecurityHeaderWhenEnabled(bool isEnabled, int maxAge, bool includeSubdomains, string expectedValue)
     {
         // Arrange
         _mockRepository.Setup(x => x.GetAsync())
@@ -416,10 +416,9 @@ public sealed class SecurityHeaderServiceTests
 
         // Act
         var headers = await _service.GetCompiledHeaders();
-        var header = headers.FirstOrDefault(x => x.Key.Equals(CspConstants.HeaderNames.StrictTransportSecurity));
+        var header = headers.FirstOrDefault(x => x.Name.Equals(CspConstants.HeaderNames.StrictTransportSecurity));
 
-        // Asser
-        Assert.That(header, Is.Not.Null);
-        Assert.That(header.Value, Is.EqualTo(expectedValue));
+        // Assert
+        Assert.That(header?.Value, Is.EqualTo(expectedValue));
     }
 }

--- a/src/Stott.Security.Optimizely/Common/CspConstants.cs
+++ b/src/Stott.Security.Optimizely/Common/CspConstants.cs
@@ -20,6 +20,8 @@ public static class CspConstants
 
     public const int TwoYearsInSeconds = 63072000;
 
+    public const int MaxHeaderSize = 8192;
+
     /// <summary>
     /// A collection of directives which can take URL style sources.
     /// </summary>

--- a/src/Stott.Security.Optimizely/Common/CspConstants.cs
+++ b/src/Stott.Security.Optimizely/Common/CspConstants.cs
@@ -126,6 +126,8 @@ public static class CspConstants
 
         public const string FrameAncestors = "frame-ancestors";
 
+        public const string FencedFrameSource = "fenced-frame-src";
+
         public const string FrameSource = "frame-src";
 
         public const string ImageSource = "img-src";
@@ -161,6 +163,10 @@ public static class CspConstants
         public const string UpgradeInsecureRequests = "upgrade-insecure-requests";
 
         public const string WorkerSource = "worker-src";
+
+        public const string ReportUri = "report-uri";
+        
+        public const string ReportTo = "report-to";
     }
 
     public static class HeaderNames

--- a/src/Stott.Security.Optimizely/Extensions/ListExtensions.cs
+++ b/src/Stott.Security.Optimizely/Extensions/ListExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Stott.Security.Optimizely.Extensions;
+
+internal static class ListExtensions
+{
+    internal static void TryAdd<TItem>(this List<TItem>? list, TItem? item)
+        where TItem : class
+    {
+        if (list is not null && item is not null)
+        {
+            list.Add(item);
+        }
+    }
+}

--- a/src/Stott.Security.Optimizely/Features/Csp/CspOptimizer.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/CspOptimizer.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Stott.Security.Optimizely.Common;
+using Stott.Security.Optimizely.Features.Csp.Dtos;
+
+namespace Stott.Security.Optimizely.Features.Csp;
+
+/// <summary>
+/// This class is intended to split a CSP header into multiple headers
+/// to avoid exceeding the maximum header size.
+/// It will group directives together based on their type.
+/// It will also ensure that the default-src sources are used as the primary fallback for any
+/// directice inheritance chain to avoid issues with the most restrictive header.
+/// This is where a restrictive default-src in one header will override
+/// a more permissive directive in another header.
+/// </summary>
+public static class CspOptimizer
+{
+    private static readonly string[] FrameSourceDirectives = new[]
+    {
+        CspConstants.Directives.FencedFrameSource,
+        CspConstants.Directives.FrameSource,
+        CspConstants.Directives.WorkerSource,
+        CspConstants.Directives.ChildSource
+    };
+
+    private static readonly string[] ScriptSourceDirectives = new[]
+    {
+        CspConstants.Directives.ScriptSourceElement,
+        CspConstants.Directives.ScriptSourceAttribute,
+        CspConstants.Directives.ScriptSource
+    };
+
+    private static readonly string[] StyleSourceDirectives = new[]
+    {
+        CspConstants.Directives.StyleSourceElement,
+        CspConstants.Directives.StyleSourceAttribute,
+        CspConstants.Directives.StyleSource
+    };
+
+    private static readonly string[] OtherFetchDirectives = new[]
+    {
+        CspConstants.Directives.ConnectSource,
+        CspConstants.Directives.FontSource,
+        CspConstants.Directives.ImageSource,
+        CspConstants.Directives.ManifestSource,
+        CspConstants.Directives.MediaSource,
+        CspConstants.Directives.ObjectSource,
+        CspConstants.Directives.PreFetchSource
+    };
+
+    private static readonly string[] StandaloneDirectives = new[]
+    {
+        CspConstants.Directives.BaseUri,
+        CspConstants.Directives.FormAction,
+        CspConstants.Directives.NavigateTo,
+        CspConstants.Directives.FrameAncestors,
+        CspConstants.Directives.UpgradeInsecureRequests,
+        CspConstants.Directives.Sandbox,
+        CspConstants.Directives.ReportTo,
+        CspConstants.Directives.ReportUri
+    };
+
+    internal static List<List<CspDirectiveDto>> GroupDirectives(List<CspDirectiveDto> cspDirectives)
+    {
+        var optimizedDirectives = new List<List<CspDirectiveDto>>();
+
+        // Get Default Source to use as a fallback, assume 'self' if not present
+        var defaultSource = cspDirectives.FirstOrDefault(d => d.Directive == CspConstants.Directives.DefaultSource)
+            ?? new CspDirectiveDto(CspConstants.Directives.DefaultSource, new List<string> { CspConstants.Sources.Self });
+
+        optimizedDirectives.Add(GetGroupedFetchDirectives(cspDirectives, defaultSource, FrameSourceDirectives, CspConstants.Directives.ChildSource));
+        optimizedDirectives.Add(GetGroupedFetchDirectives(cspDirectives, defaultSource, ScriptSourceDirectives, CspConstants.Directives.ScriptSource));
+        optimizedDirectives.Add(GetGroupedFetchDirectives(cspDirectives, defaultSource, StyleSourceDirectives, CspConstants.Directives.StyleSource));
+        optimizedDirectives.AddRange(GetGroupedFetchDirectives(cspDirectives, defaultSource, OtherFetchDirectives));
+        optimizedDirectives.AddRange(GetGroupedStandaloneDirectives(cspDirectives, StandaloneDirectives));
+
+        return optimizedDirectives;
+    }
+
+    private static List<CspDirectiveDto> GetGroupedFetchDirectives(
+        List<CspDirectiveDto> cspDirectives,
+        CspDirectiveDto defaultSource,
+        string[] directiveNames,
+        string primaryFallback)
+    {
+        var matchingDirectives = cspDirectives
+            .Where(d => directiveNames.Contains(d.Directive))
+            .ToList();
+
+        if (ExceedsHeaderLength(matchingDirectives))
+        {
+            var allSources = matchingDirectives.SelectMany(d => d.Sources).Distinct().ToList();
+            matchingDirectives.Clear();
+            matchingDirectives.Add(new CspDirectiveDto(primaryFallback, allSources));
+        }
+
+        if (matchingDirectives.Count == 0 || !matchingDirectives.Any(x => x.Directive == primaryFallback))
+        {
+            matchingDirectives.Add(new CspDirectiveDto(primaryFallback, defaultSource.Sources));
+        }
+
+        return matchingDirectives;
+    }
+
+    private static List<List<CspDirectiveDto>> GetGroupedFetchDirectives(
+        List<CspDirectiveDto> cspDirectives,
+        CspDirectiveDto defaultSource,
+        string[] directiveNames)
+    {
+        var matchingDirectives = new List<CspDirectiveDto>(directiveNames.Length);
+        foreach (var directiveName in directiveNames)
+        {
+            var directive = cspDirectives.FirstOrDefault(d => d.Directive == directiveName)
+                        ?? new CspDirectiveDto(directiveName, defaultSource.Sources);
+            matchingDirectives.Add(directive);
+        }
+
+        return GroupWithHeaderSizeLimits(matchingDirectives);
+    }
+
+    private static List<List<CspDirectiveDto>> GetGroupedStandaloneDirectives(List<CspDirectiveDto> cspDirectives, string[] directiveNames)
+    {
+        var matchingDirectives = cspDirectives
+            .Where(d => directiveNames.Contains(d.Directive))
+            .ToList();
+
+        return GroupWithHeaderSizeLimits(matchingDirectives);
+    }
+
+    private static List<List<CspDirectiveDto>> GroupWithHeaderSizeLimits(List<CspDirectiveDto> cspDirectives)
+    {
+        if (!ExceedsHeaderLength(cspDirectives))
+        {
+            return new List<List<CspDirectiveDto>> { cspDirectives };
+        }
+
+        // At this point we will break header size with just these directives
+        // I want to group these into as few a groups as possible where no group
+        // has a sum of PredictedSize that exceeds the max header size
+        // This is a greedy algorithm, it will not always produce the optimal solution
+        // but it will produce a solution that is better than the original
+        var groupedDirectives = new List<List<CspDirectiveDto>>();
+        var currentGroup = new List<CspDirectiveDto>();
+        var currentGroupSize = 0;
+
+        foreach (var directive in cspDirectives)
+        {
+            if (currentGroupSize + directive.PredictedSize > CspConstants.MaxHeaderSize)
+            {
+                groupedDirectives.Add(currentGroup);
+                currentGroup = new List<CspDirectiveDto>();
+                currentGroupSize = 0;
+            }
+
+            currentGroup.Add(directive);
+            currentGroupSize += directive.PredictedSize;
+        }
+
+        if (currentGroup.Count > 0)
+        {
+            groupedDirectives.Add(currentGroup);
+        }
+
+        return groupedDirectives;
+    }
+
+    private static bool ExceedsHeaderLength(IList<CspDirectiveDto> directives)
+    {
+        return directives.Sum(d => d.PredictedSize) > CspConstants.MaxHeaderSize;
+    }
+}

--- a/src/Stott.Security.Optimizely/Features/Csp/CspService.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/CspService.cs
@@ -83,18 +83,18 @@ public sealed class CspService : ICspService
             var cspContents = BuildSplitCspContent(settings, sandbox, globalSources, pageSources);
             foreach (var cspContent in cspContents)
             {
-                yield return new HeaderDto { Name = headerName, Value = cspContent };
+                yield return new HeaderDto { Key = headerName, Value = cspContent };
             }
         }
         else
         {
-            yield return new HeaderDto { Name = headerName, Value = singleCspContent };
+            yield return new HeaderDto { Key = headerName, Value = singleCspContent };
         }
 
         var reportingEndPoints = GetReportingEndPoints(settings).ToList();
         if (reportingEndPoints is { Count: >0 })
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.ReportingEndpoints, Value = string.Join(", ", reportingEndPoints) };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.ReportingEndpoints, Value = string.Join(", ", reportingEndPoints) };
         }
     }
 

--- a/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspDirectiveDto.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspDirectiveDto.cs
@@ -25,6 +25,6 @@ internal sealed class CspDirectiveDto
 
     public override string ToString()
     {
-        return $"{Directive} {string.Join(" ", Sources)}; ";
+        return Sources is { Count: > 0 } ? $"{Directive} {string.Join(" ", Sources)}; " : $"{Directive}; ";
     }
 }

--- a/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspDirectiveDto.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspDirectiveDto.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stott.Security.Optimizely.Features.Csp.Dtos;
+
+internal sealed class CspDirectiveDto
+{
+    public string Directive { get; }
+
+    public IList<string> Sources { get; }
+
+    public int PredictedSize { get; }
+
+    public CspDirectiveDto(string directive, IList<string> sources)
+    {
+        Directive = directive;
+        Sources = sources.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        PredictedSize = Directive.Length + 3 + Sources.Sum(s => s.Length + 1);
+    }
+
+    public CspDirectiveDto(string directive, string source)
+        : this(directive, new List<string> { source })
+    {
+    }
+
+    public override string ToString()
+    {
+        return $"{Directive} {string.Join(" ", Sources)}; ";
+    }
+}

--- a/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspSourceDto.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/Dtos/CspSourceDto.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stott.Security.Optimizely.Features.Csp.Dtos;
+
+internal sealed class CspSourceDto
+{
+    public string Source { get; }
+
+    public List<string> Directives { get; }
+
+    public CspSourceDto(string? source, string? directives)
+    {
+        Source = source ?? string.Empty;
+        Directives = directives?.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Distinct().ToList() ?? new List<string>(0);
+    }
+}

--- a/src/Stott.Security.Optimizely/Features/Csp/ICspService.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/ICspService.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.Pages;
 
 namespace Stott.Security.Optimizely.Features.Csp;
 
 public interface ICspService
 {
-    Task<IEnumerable<KeyValuePair<string, string>>> GetCompiledHeaders(IContentSecurityPolicyPage? currentPage);
+    Task<IEnumerable<HeaderDto>> GetCompiledHeaders(IContentSecurityPolicyPage? currentPage);
 }

--- a/src/Stott.Security.Optimizely/Features/Header/HeaderCompilationService.cs
+++ b/src/Stott.Security.Optimizely/Features/Header/HeaderCompilationService.cs
@@ -89,22 +89,15 @@ internal sealed class HeaderCompilationService : IHeaderCompilationService
         var nonceValue = _nonceProvider.GetCspValue();
         foreach (var header in headers)
         {
-            if (header.Name == CspConstants.HeaderNames.ContentSecurityPolicy ||
-                header.Name == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy)
+            if (header.Key == CspConstants.HeaderNames.ContentSecurityPolicy ||
+                header.Key == CspConstants.HeaderNames.ReportOnlyContentSecurityPolicy)
             {
-                yield return new HeaderDto { Name = header.Name, Value = header.Value?.Replace(CspConstants.NoncePlaceholder, nonceValue) };
+                yield return new HeaderDto { Key = header.Key, Value = header.Value?.Replace(CspConstants.NoncePlaceholder, nonceValue) };
             }
             else
             {
-                yield return new HeaderDto { Name = header.Name, Value = header.Value };
+                yield return new HeaderDto { Key = header.Key, Value = header.Value };
             }
         }
     }
-}
-
-public sealed class HeaderDto
-{
-    public string? Name { get; set; }
-
-    public string? Value { get; set; }
 }

--- a/src/Stott.Security.Optimizely/Features/Header/HeaderDto.cs
+++ b/src/Stott.Security.Optimizely/Features/Header/HeaderDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Stott.Security.Optimizely.Features.Header;
+
+public sealed class HeaderDto
+{
+    public string? Key { get; set; }
+
+    public string? Value { get; set; }
+}

--- a/src/Stott.Security.Optimizely/Features/Header/IHeaderCompilationService.cs
+++ b/src/Stott.Security.Optimizely/Features/Header/IHeaderCompilationService.cs
@@ -7,5 +7,5 @@ using EPiServer.Core;
 
 public interface IHeaderCompilationService
 {
-    Task<Dictionary<string, string>> GetSecurityHeadersAsync(PageData? pageData);
+    Task<List<KeyValuePair<string, string>>> GetSecurityHeadersAsync(PageData? pageData);
 }

--- a/src/Stott.Security.Optimizely/Features/Header/IHeaderCompilationService.cs
+++ b/src/Stott.Security.Optimizely/Features/Header/IHeaderCompilationService.cs
@@ -7,5 +7,5 @@ using EPiServer.Core;
 
 public interface IHeaderCompilationService
 {
-    Task<List<KeyValuePair<string, string>>> GetSecurityHeadersAsync(PageData? pageData);
+    Task<List<HeaderDto>> GetSecurityHeadersAsync(PageData? pageData);
 }

--- a/src/Stott.Security.Optimizely/Features/LandingPage/SettingsLandingPageController.cs
+++ b/src/Stott.Security.Optimizely/Features/LandingPage/SettingsLandingPageController.cs
@@ -1,13 +1,13 @@
 ﻿namespace Stott.Security.Optimizely.Features.LandingPage;
 
 using System.Reflection;
+
 using EPiServer.Framework.ClientResources;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Net.Http.Headers;
 
 using Stott.Security.Optimizely.Common;
-using Stott.Security.Optimizely.Extensions;
 using Stott.Security.Optimizely.Features.StaticFile;
 
 [ApiExplorerSettings(IgnoreApi = true)]
@@ -45,8 +45,6 @@ public sealed class SettingsLandingPageController : Controller
         {
             return NotFound("The requested file does not exist.");
         }
-
-        Response.Headers.AddOrUpdateHeader(HeaderNames.CacheControl, "public, max-age=31557600");
 
         return File(fileBytes, mimeType);
     }

--- a/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
+++ b/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿namespace Stott.Security.Optimizely.Features.Middleware;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 using EPiServer.Logging;
@@ -34,7 +35,10 @@ public sealed class SecurityHeaderMiddleware
             var headers = await securityHeaderService.GetSecurityHeadersAsync(pageData);
             foreach (var header in headers)
             {
-                context.Response.Headers.Append(header.Key, header.Value);
+                if (!string.IsNullOrWhiteSpace(header.Name) && !string.IsNullOrWhiteSpace(header.Value))
+                {
+                    context.Response.Headers.Append(header.Name, header.Value);
+                }
             }
         }
         catch (Exception exception)

--- a/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
+++ b/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿namespace Stott.Security.Optimizely.Features.Middleware;
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 using EPiServer.Logging;
@@ -10,7 +9,6 @@ using EPiServer.Web.Routing;
 using Microsoft.AspNetCore.Http;
 
 using Stott.Security.Optimizely.Common;
-using Stott.Security.Optimizely.Extensions;
 using Stott.Security.Optimizely.Features.Header;
 
 public sealed class SecurityHeaderMiddleware

--- a/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
+++ b/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
@@ -33,9 +33,9 @@ public sealed class SecurityHeaderMiddleware
             var headers = await securityHeaderService.GetSecurityHeadersAsync(pageData);
             foreach (var header in headers)
             {
-                if (!string.IsNullOrWhiteSpace(header.Name) && !string.IsNullOrWhiteSpace(header.Value))
+                if (!string.IsNullOrWhiteSpace(header.Key) && !string.IsNullOrWhiteSpace(header.Value))
                 {
-                    context.Response.Headers.Append(header.Name, header.Value);
+                    context.Response.Headers.Append(header.Key, header.Value);
                 }
             }
         }

--- a/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
+++ b/src/Stott.Security.Optimizely/Features/Middleware/SecurityHeaderMiddleware.cs
@@ -34,7 +34,7 @@ public sealed class SecurityHeaderMiddleware
             var headers = await securityHeaderService.GetSecurityHeadersAsync(pageData);
             foreach (var header in headers)
             {
-                context.Response.Headers.AddOrUpdateHeader(header.Key, header.Value);
+                context.Response.Headers.Append(header.Key, header.Value);
             }
         }
         catch (Exception exception)

--- a/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/IPermissionPolicyService.cs
+++ b/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/IPermissionPolicyService.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.PermissionPolicy.Models;
 
 namespace Stott.Security.Optimizely.Features.PermissionPolicy.Service;
@@ -10,7 +12,7 @@ public interface IPermissionPolicyService
 
     Task<IList<PermissionPolicyDirectiveModel>> ListDirectivesAsync(string? sourceFilter, PermissionPolicyEnabledFilter enabledFilter);
 
-    Task<IEnumerable<KeyValuePair<string, string>>> GetCompiledHeaders();
+    Task<IEnumerable<HeaderDto>> GetCompiledHeaders();
 
     Task SaveDirectiveAsync(SavePermissionPolicyModel? model, string? modifiedBy);
 

--- a/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/PermissionPolicyService.cs
+++ b/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/PermissionPolicyService.cs
@@ -87,7 +87,7 @@ public sealed class PermissionPolicyService : IPermissionPolicyService
 
         if (cachedData is { IsEnabled: true, Directives.Count: > 0 })
         {
-            compiledHeaders.Add(new HeaderDto { Name = PermissionPolicyConstants.PermissionPolicyHeader, Value = string.Join(", ", cachedData.Directives) });
+            compiledHeaders.Add(new HeaderDto { Key = PermissionPolicyConstants.PermissionPolicyHeader, Value = string.Join(", ", cachedData.Directives) });
         }
 
         return compiledHeaders;

--- a/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/PermissionPolicyService.cs
+++ b/src/Stott.Security.Optimizely/Features/PermissionPolicy/Service/PermissionPolicyService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Stott.Security.Optimizely.Features.Caching;
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.PermissionPolicy.Models;
 using Stott.Security.Optimizely.Features.PermissionPolicy.Repository;
 
@@ -64,9 +65,9 @@ public sealed class PermissionPolicyService : IPermissionPolicyService
         return directives.Where(x => IsMatch(x, sourceFilter, enabledFilter)).ToList();
     }
 
-    public async Task<IEnumerable<KeyValuePair<string, string>>> GetCompiledHeaders()
+    public async Task<IEnumerable<HeaderDto>> GetCompiledHeaders()
     {
-        var compiledHeaders = new List<KeyValuePair<string, string>>();
+        var compiledHeaders = new List<HeaderDto>();
         var cachedData = _cache.Get<CompiledPermissionPolicy>(CompiledHeaderCacheKey);
         if (cachedData is null)
         {
@@ -86,7 +87,7 @@ public sealed class PermissionPolicyService : IPermissionPolicyService
 
         if (cachedData is { IsEnabled: true, Directives.Count: > 0 })
         {
-            compiledHeaders.Add(new KeyValuePair<string, string>(PermissionPolicyConstants.PermissionPolicyHeader, string.Join(", ", cachedData.Directives)));
+            compiledHeaders.Add(new HeaderDto { Name = PermissionPolicyConstants.PermissionPolicyHeader, Value = string.Join(", ", cachedData.Directives) });
         }
 
         return compiledHeaders;

--- a/src/Stott.Security.Optimizely/Features/Preview/CompiledHeaderController.cs
+++ b/src/Stott.Security.Optimizely/Features/Preview/CompiledHeaderController.cs
@@ -36,7 +36,7 @@ public sealed class CompiledHeaderController : BaseController
         var headers = await _securityHeaderService.GetSecurityHeadersAsync(pageData);
 
         var sortedHeaders = headers.Where(x => !string.IsNullOrWhiteSpace(x.Value))
-                                   .OrderBy(x => x.Key)
+                                   .OrderBy(x => x.Name)
                                    .ToList();
 
         return CreateSuccessJson(sortedHeaders);
@@ -49,7 +49,7 @@ public sealed class CompiledHeaderController : BaseController
     {
         var pageData = GetPageData(pageId);
         var headers = await _securityHeaderService.GetSecurityHeadersAsync(pageData);
-        var headerValue = headers.Where(x => string.Equals(x.Key, headerName, StringComparison.OrdinalIgnoreCase))
+        var headerValue = headers.Where(x => string.Equals(x.Name, headerName, StringComparison.OrdinalIgnoreCase))
                                  .Select(x => x.Value)
                                  .FirstOrDefault();
 

--- a/src/Stott.Security.Optimizely/Features/Preview/CompiledHeaderController.cs
+++ b/src/Stott.Security.Optimizely/Features/Preview/CompiledHeaderController.cs
@@ -36,7 +36,7 @@ public sealed class CompiledHeaderController : BaseController
         var headers = await _securityHeaderService.GetSecurityHeadersAsync(pageData);
 
         var sortedHeaders = headers.Where(x => !string.IsNullOrWhiteSpace(x.Value))
-                                   .OrderBy(x => x.Name)
+                                   .OrderBy(x => x.Key)
                                    .ToList();
 
         return CreateSuccessJson(sortedHeaders);
@@ -49,7 +49,7 @@ public sealed class CompiledHeaderController : BaseController
     {
         var pageData = GetPageData(pageId);
         var headers = await _securityHeaderService.GetSecurityHeadersAsync(pageData);
-        var headerValue = headers.Where(x => string.Equals(x.Name, headerName, StringComparison.OrdinalIgnoreCase))
+        var headerValue = headers.Where(x => string.Equals(x.Key, headerName, StringComparison.OrdinalIgnoreCase))
                                  .Select(x => x.Value)
                                  .FirstOrDefault();
 

--- a/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/ISecurityHeaderService.cs
+++ b/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/ISecurityHeaderService.cs
@@ -3,13 +3,14 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.SecurityHeaders.Enums;
 
 public interface ISecurityHeaderService
 {
     Task<SecurityHeaderModel> GetAsync();
 
-    Task<IEnumerable<KeyValuePair<string, string>>> GetCompiledHeaders();
+    Task<IEnumerable<HeaderDto>> GetCompiledHeaders();
 
     Task SaveAsync(
         XContentTypeOptions xContentTypeOptions,

--- a/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/SecurityHeaderService.cs
+++ b/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/SecurityHeaderService.cs
@@ -142,42 +142,42 @@ internal sealed class SecurityHeaderService : ISecurityHeaderService
 
         if (settings.XContentTypeOptions != XContentTypeOptions.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.ContentTypeOptions, Value = settings.XContentTypeOptions.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.ContentTypeOptions, Value = settings.XContentTypeOptions.GetSecurityHeaderValue() };
         }
 
         if (settings.XssProtection != XssProtection.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.XssProtection, Value = settings.XssProtection.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.XssProtection, Value = settings.XssProtection.GetSecurityHeaderValue() };
         }
 
         if (settings.ReferrerPolicy != ReferrerPolicy.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.ReferrerPolicy, Value = settings.ReferrerPolicy.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.ReferrerPolicy, Value = settings.ReferrerPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.FrameOptions != XFrameOptions.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.FrameOptions, Value = settings.FrameOptions.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.FrameOptions, Value = settings.FrameOptions.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginEmbedderPolicy != CrossOriginEmbedderPolicy.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginEmbedderPolicy, Value = settings.CrossOriginEmbedderPolicy.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.CrossOriginEmbedderPolicy, Value = settings.CrossOriginEmbedderPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginOpenerPolicy != CrossOriginOpenerPolicy.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginOpenerPolicy, Value = settings.CrossOriginOpenerPolicy.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.CrossOriginOpenerPolicy, Value = settings.CrossOriginOpenerPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginResourcePolicy != CrossOriginResourcePolicy.None)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginResourcePolicy, Value = settings.CrossOriginResourcePolicy.GetSecurityHeaderValue() };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.CrossOriginResourcePolicy, Value = settings.CrossOriginResourcePolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.IsStrictTransportSecurityEnabled)
         {
-            yield return new HeaderDto { Name = CspConstants.HeaderNames.StrictTransportSecurity, Value = GetStrictTransportSecurityValue(settings) };
+            yield return new HeaderDto { Key = CspConstants.HeaderNames.StrictTransportSecurity, Value = GetStrictTransportSecurityValue(settings) };
         }
     }
 

--- a/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/SecurityHeaderService.cs
+++ b/src/Stott.Security.Optimizely/Features/SecurityHeaders/Service/SecurityHeaderService.cs
@@ -9,6 +9,7 @@ using Stott.Security.Optimizely.Common;
 using Stott.Security.Optimizely.Entities;
 using Stott.Security.Optimizely.Extensions;
 using Stott.Security.Optimizely.Features.Caching;
+using Stott.Security.Optimizely.Features.Header;
 using Stott.Security.Optimizely.Features.SecurityHeaders.Enums;
 using Stott.Security.Optimizely.Features.SecurityHeaders.Repository;
 
@@ -35,7 +36,7 @@ internal sealed class SecurityHeaderService : ISecurityHeaderService
         return SecurityHeaderMapper.ToModel(settings);
     }
 
-    public async Task<IEnumerable<KeyValuePair<string, string>>> GetCompiledHeaders()
+    public async Task<IEnumerable<HeaderDto>> GetCompiledHeaders()
     {
         var settings = await this.GetSettingsData();
 
@@ -132,7 +133,7 @@ internal sealed class SecurityHeaderService : ISecurityHeaderService
         return settings;
     }
 
-    private static IEnumerable<KeyValuePair<string, string>> BuildHeaders(SecurityHeaderSettings settings)
+    private static IEnumerable<HeaderDto> BuildHeaders(SecurityHeaderSettings settings)
     {
         if (settings is null)
         {
@@ -141,42 +142,42 @@ internal sealed class SecurityHeaderService : ISecurityHeaderService
 
         if (settings.XContentTypeOptions != XContentTypeOptions.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.ContentTypeOptions, settings.XContentTypeOptions.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.ContentTypeOptions, Value = settings.XContentTypeOptions.GetSecurityHeaderValue() };
         }
 
         if (settings.XssProtection != XssProtection.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.XssProtection, settings.XssProtection.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.XssProtection, Value = settings.XssProtection.GetSecurityHeaderValue() };
         }
 
         if (settings.ReferrerPolicy != ReferrerPolicy.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.ReferrerPolicy, settings.ReferrerPolicy.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.ReferrerPolicy, Value = settings.ReferrerPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.FrameOptions != XFrameOptions.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.FrameOptions, settings.FrameOptions.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.FrameOptions, Value = settings.FrameOptions.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginEmbedderPolicy != CrossOriginEmbedderPolicy.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.CrossOriginEmbedderPolicy, settings.CrossOriginEmbedderPolicy.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginEmbedderPolicy, Value = settings.CrossOriginEmbedderPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginOpenerPolicy != CrossOriginOpenerPolicy.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.CrossOriginOpenerPolicy, settings.CrossOriginOpenerPolicy.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginOpenerPolicy, Value = settings.CrossOriginOpenerPolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.CrossOriginResourcePolicy != CrossOriginResourcePolicy.None)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.CrossOriginResourcePolicy, settings.CrossOriginResourcePolicy.GetSecurityHeaderValue());
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.CrossOriginResourcePolicy, Value = settings.CrossOriginResourcePolicy.GetSecurityHeaderValue() };
         }
 
         if (settings.IsStrictTransportSecurityEnabled)
         {
-            yield return new KeyValuePair<string, string>(CspConstants.HeaderNames.StrictTransportSecurity, GetStrictTransportSecurityValue(settings));
+            yield return new HeaderDto { Name = CspConstants.HeaderNames.StrictTransportSecurity, Value = GetStrictTransportSecurityValue(settings) };
         }
     }
 


### PR DESCRIPTION
Added stratagems for handling CSP header size being too large:

1. Merges script-src, script-src-elem and script-src-attr if the CSP exceeds the header size.
2. Merges style-src, style-src-elem and style-src-attr if the CSP exceeds the header size.
3. If the result of merging still exceeds the size, then the CSP is not used.

Closes 279

Initial work limits to 8kb for greater support.  But will look to 16kb if support is wide enough.