### PR TITLE
Move URL generation for the report-to endpoint to happen after retrieval from the cache.

### DIFF
--- a/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/CspServiceTests.cs
@@ -31,14 +31,9 @@ public sealed class CspServiceTests
 
     private Mock<IContentSecurityPolicyPage> _mockPage;
 
-    private Mock<ICspReportUrlResolver> _mockReportUrlResolver;
-
     [SetUp]
     public void SetUp()
     {
-        _mockReportUrlResolver = new Mock<ICspReportUrlResolver>();
-        _mockReportUrlResolver.Setup(x => x.GetReportToPath()).Returns("https://www.example.com/");
-
         _mockSettingsService = new Mock<ICspSettingsService>();
 
         _mockSandboxService = new Mock<ICspSandboxService>();
@@ -50,8 +45,7 @@ public sealed class CspServiceTests
         _cspService = new CspService(
             _mockSettingsService.Object,
             _mockPermissionService.Object,
-            _mockSandboxService.Object,
-            _mockReportUrlResolver.Object);
+            _mockSandboxService.Object);
     }
 
     [Test]

--- a/src/Stott.Security.Optimizely/Common/CspConstants.cs
+++ b/src/Stott.Security.Optimizely/Common/CspConstants.cs
@@ -14,6 +14,8 @@ public static class CspConstants
 
     public const string NoncePlaceholder = "##NONCE##";
 
+    public const string InternalReportingPlaceholder = "##INTERNAL_REPORTING##";
+
     public const string StrictDynamic = "'strict-dynamic'";
 
     public static int LogRetentionDays => 30;

--- a/src/Stott.Security.Optimizely/Features/Csp/CspService.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/CspService.cs
@@ -23,18 +23,14 @@ public sealed class CspService : ICspService
 
     private readonly ICspSandboxService _cspSandboxService;
 
-    private readonly ICspReportUrlResolver _cspReportUrlResolver;
-
     public CspService(
         ICspSettingsService cspSettingsService,
         ICspPermissionService cspPermissionService,
-        ICspSandboxService cspSandboxService,
-        ICspReportUrlResolver cspReportUrlResolver)
+        ICspSandboxService cspSandboxService)
     {
         _cspSettingsService = cspSettingsService;
         _cspPermissionService = cspPermissionService;
         _cspSandboxService = cspSandboxService;
-        _cspReportUrlResolver = cspReportUrlResolver;
     }
 
     public async Task<IEnumerable<HeaderDto>> GetCompiledHeaders(IContentSecurityPolicyPage? currentPage)
@@ -227,11 +223,11 @@ public sealed class CspService : ICspService
         }
     }
 
-    private IEnumerable<string> GetReportingEndPoints(CspSettings settings)
+    private static IEnumerable<string> GetReportingEndPoints(CspSettings settings)
     {
         if (settings is { IsEnabled: true, UseInternalReporting: true })
         {
-            yield return $"stott-security-endpoint=\"{_cspReportUrlResolver.GetReportToPath()}\"";
+            yield return $"stott-security-endpoint=\"{CspConstants.InternalReportingPlaceholder}\"";
         }
 
         if (settings is { IsEnabled: true, UseExternalReporting: true, ExternalReportToUrl.Length: > 0 })


### PR DESCRIPTION
Use a placeholder in the header cache and populate when returning to the frontend