### PR TITLE
Fix CSP Source Validation — Improve Regex to Match CSP Spec (#259)

### DIFF
--- a/src/Stott.Security.Optimizely.Test/Features/Csp/Permissions/Save/SavePermissionModelTestCases.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/Permissions/Save/SavePermissionModelTestCases.cs
@@ -59,10 +59,9 @@ public static class SavePermissionModelTestCases
             yield return new TestCaseData("http://www.example.com:80");
             yield return new TestCaseData("http://www.example.com/");
             yield return new TestCaseData("http://www.example.com/something");
-            yield return new TestCaseData("http://www.example.com/something");
             yield return new TestCaseData("https://www.example.com");
+            yield return new TestCaseData("https://www.EXAMPLE.com");
             yield return new TestCaseData("https://www.example.com/");
-            yield return new TestCaseData("https://www.example.com/something");
             yield return new TestCaseData("https://www.example.com/something");
             yield return new TestCaseData("*.mailsite.com");
             yield return new TestCaseData("https://onlinebanking.jumbobank.com");
@@ -78,6 +77,12 @@ public static class SavePermissionModelTestCases
             yield return new TestCaseData("http://www.example.io");
             yield return new TestCaseData("https://www.example.co");
             yield return new TestCaseData("https://www.example.io");
+            yield return new TestCaseData("https://abc1d23456de7f890g12-h34ijklm567nop890qr12stu3v4567wx.ssl.cf5.rackcdn.com/1234/v4.3.2iframeResizer.min.js");
+            yield return new TestCaseData("https://example.com/xyZxYzabcDEFghij-eu1/zaius-min.js");
+            yield return new TestCaseData("https://example.com/Test@test");
+            yield return new TestCaseData("x.com");
+            yield return new TestCaseData("https://x.com");            
+            yield return new TestCaseData("https://*");
         }
     }
 

--- a/src/Stott.Security.Optimizely/Common/CspConstants.cs
+++ b/src/Stott.Security.Optimizely/Common/CspConstants.cs
@@ -195,7 +195,7 @@ public static class CspConstants
 
     public static class RegexPatterns
     {
-        public const string UrlDomain = "^([a-z0-9\\/\\-\\._\\:\\*\\[\\]\\@]{3,}\\.{1}[a-z0-9\\/\\-\\._\\:\\*\\[\\]\\@]{2,})$";
+        public const string UrlDomain = @"^(?:[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?(?:\*\.[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+|[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+|\*)(?::\d+|:\*)?(?:\/[^\s]*)?$";
 
         public const string UrlLocalHost = "^([a-z]{2,5}\\:{1}\\/\\/localhost\\:([0-9]{1,5}|\\*{1}))$";
     }


### PR DESCRIPTION
Fixes #259: Some valid CSP source URLs were rejected.

# What's changed: 
The UrlDomain regular expression was updated. The previous implementation incorrectly rejected several valid sources, including:

- Short domains without schemes (e.g., t.co, x.com).
- URLs with uppercase characters in the path (e.g., https://d1igp3oop3iho5.cloudfront.net/v2/aBC1DeefgH2ij-eu1/zaius-min.js).
- Long subdomain structures like https://aaf1a18515da0e792f78-c27fdabe952dfc357fe25ebf5c8897ee.ssl.cf5.rackcdn.com/....

## Updated Regex 
```csharp
public const string UrlDomain = @"^(?:[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?(?:\*\.[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+|[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+|\*)(?::\d+|:\*)?(?:\/[^\s]*)?$";
```

##  Regex Explanation

```regex
^(?:[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?
(?:\*\.[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+ | [a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+ | \*)
(?::\d+|:\*)?
(?:\/[^\s]*)?$
```

## Regex Breakdown
- `^ ... $`

  - Asserts start and end of the string, ensuring full string match.

- `(?:[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)?`

  - Optional scheme, e.g., http://, https://, ws://.

  - Starts with a letter, followed by any combination of letters, digits, `+`, `-`, or `.`.

  - Ends with `://`.

  - Entire group is optional.

- `(?:\*\.[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+ | [a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)+ | \*)`

- Domain or wildcard:

  - `*.example.com` — Wildcard subdomain (requires at least one dot).

  - `example.com` — Regular domain (requires at least one dot).

  - `* —` Wildcard for any domain.

- `(?::\d+|:\*)?`

  - Optional port:

    - `:443` — Specific numeric port.

    - `:*` — Wildcard port.

- `(?:\/[^\s]*)?`

  - Optional path:

    - `/path/to/resource` — Anything after `/ `except whitespace.
    
 ## Notes
 This updated regex was prepared and validated with the help of **ChatGPT** , based on teh official CSP specification ( [ ](https://www.w3.org/TR/CSP/#framework-directive-source-list))  
