### PR TITLE
Use first matching GUID ID when grouping report summaries instead of …

### DIFF
--- a/src/Stott.Security.Optimizely.Test/Features/Csp/Reporting/ViolationReportSummaryTests.cs
+++ b/src/Stott.Security.Optimizely.Test/Features/Csp/Reporting/ViolationReportSummaryTests.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 using Stott.Security.Optimizely.Features.Csp.Reporting;
 
 [TestFixture]
-public class ViolationReportSummaryTests
+public sealed class ViolationReportSummaryTests
 {
     [Test]
     [TestCaseSource(typeof(ViolationReportSummaryTestCases), nameof(ViolationReportSummaryTestCases.SanitizedSourceTestCases))]
@@ -18,7 +18,7 @@ public class ViolationReportSummaryTests
         string expectedSanitizedSource)
     {
         // Arrange
-        var summary = new ViolationReportSummary(1, source, string.Empty, 1, DateTime.Now);
+        var summary = new ViolationReportSummary(Guid.NewGuid(), source, string.Empty, 1, DateTime.Now);
 
         // Assert
         Assert.That(summary.SanitizedSource, Is.EqualTo(expectedSanitizedSource));
@@ -29,7 +29,7 @@ public class ViolationReportSummaryTests
     public void CreatesAppropriateSuggestionsForWildCardDomains(string source, IList<string> expectedSuggestions)
     {
         // Arrange
-        var summary = new ViolationReportSummary(1, source, string.Empty, 1, DateTime.Now);
+        var summary = new ViolationReportSummary(Guid.NewGuid(), source, string.Empty, 1, DateTime.Now);
 
         // Assert
         Assert.That(summary.SourceSuggestions, Is.EquivalentTo(expectedSuggestions));
@@ -40,7 +40,7 @@ public class ViolationReportSummaryTests
     public void CreatesASingleSuggestionMatchingTheSourceWhenSourceIsNotAUrl(string source)
     {
         // Arrange
-        var summary = new ViolationReportSummary(1, source, string.Empty, 1, DateTime.Now);
+        var summary = new ViolationReportSummary(Guid.NewGuid(), source, string.Empty, 1, DateTime.Now);
 
         // Assert
         Assert.Multiple(() =>
@@ -55,7 +55,7 @@ public class ViolationReportSummaryTests
     public void CreatesAppropriateSuggestionsForDirectives(string directive, IList<string> expectedDirectives)
     {
         // Arrange
-        var summary = new ViolationReportSummary(1, string.Empty, directive, 1, DateTime.Now);
+        var summary = new ViolationReportSummary(Guid.NewGuid(), string.Empty, directive, 1, DateTime.Now);
 
         // Assert
         Assert.That(summary.DirectiveSuggestions, Is.EquivalentTo(expectedDirectives));

--- a/src/Stott.Security.Optimizely/Features/Csp/Reporting/Repository/CspViolationReportRepository.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/Reporting/Repository/CspViolationReportRepository.cs
@@ -78,6 +78,7 @@ internal sealed class CspViolationReportRepository : ICspViolationReportReposito
                                 } into violationGroup
                                 select new
                                 {
+                                    Id = violationGroup.Min(x => x.Id),
                                     Source = violationGroup.Key.BlockedUri,
                                     Directive = violationGroup.Key.ViolatedDirective,
                                     Violations = violationGroup.Sum(y => y.Instances),
@@ -96,7 +97,7 @@ internal sealed class CspViolationReportRepository : ICspViolationReportReposito
 
         // Convert to a model collection with a unique Id per row.
         return violations.Where(x => x.LastViolated >= threshold)
-                         .Select((x, i) => new ViolationReportSummary(i, x.Source, x.Directive, x.Violations, x.LastViolated))
+                         .Select(x => new ViolationReportSummary(x.Id, x.Source, x.Directive, x.Violations, x.LastViolated))
                          .OrderByDescending(x => x.LastViolated)
                          .ToList();
     }

--- a/src/Stott.Security.Optimizely/Features/Csp/Reporting/ViolationReportSummary.cs
+++ b/src/Stott.Security.Optimizely/Features/Csp/Reporting/ViolationReportSummary.cs
@@ -8,7 +8,7 @@ using Stott.Security.Optimizely.Common;
 
 public sealed class ViolationReportSummary
 {
-    public int Key { get; }
+    public Guid Key { get; }
 
     public string Source { get; }
 
@@ -25,7 +25,7 @@ public sealed class ViolationReportSummary
     public DateTime LastViolated { get; set; }
 
     public ViolationReportSummary(
-        int key,
+        Guid key,
         string? source,
         string? directive,
         int violations,


### PR DESCRIPTION
Use first matching GUID ID when grouping report summaries instead of generating an integer id.

Closes #302 