### PR TITLE
fix(audit): add missing security.txt option to record filter

### DIFF
--- a/src/Stott.Security.Ui/src/Audit/AuditHistory.jsx
+++ b/src/Stott.Security.Ui/src/Audit/AuditHistory.jsx
@@ -199,6 +199,7 @@ function AuditHistory(props) {
                                 <option value='CSP Source'>CSP Source</option>
                                 <option value='CSP Sandbox'>CSP Sandbox</option>
                                 <option value='Security Header Settings'>Security Header Settings</option>
+                                <option value='security.txt'>security.txt</option>
                             </Form.Select>
                         </Form.Group>
                     </div>


### PR DESCRIPTION
# Description

This PR addresses issue #336 where the "security.txt" option was missing from the Record filter dropdown in the Audit tab. 

While the backend was correctly generating audit entries for security.txt configurations with the record type `security.txt`, the frontend UI did not provide a way for users to filter specifically for these entries.

### Changes 

- Added `security.txt` as a selectable option in the **Record** filter dropdown within the Audit History view.
- Ensured the filter value matches the exact string used by the backend audit repository.

### Manual Verification

1. Navigated to the Audit tab.
2. Verified that "security.txt" is now visible in the **Record** dropdown.
3. Confirmed that selecting this option correctly filters the audit logs to show only security.txt related changes.

Fixes #336